### PR TITLE
Add Active as Source

### DIFF
--- a/lib/plugins/source/activeSchemeSource.js
+++ b/lib/plugins/source/activeSchemeSource.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/**
+ * This is a source mixin for SchemePunk. Which uses the active scheme as the
+ * source rather than the original source.
+ * SchemePunk mixins follow the formula for mixins described at:
+ * http://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/
+ * More info in the README.
+ *
+ */
+module.exports = superclass => class extends superclass {
+  /**
+   * Function to set the active scheme as the origin.
+   */
+  setOrigin() {
+    this.retrievedOrigin = this.scheme.activeScheme;
+    if (super.setOrigin) super.setOrigin(this.retrievedOrigin);
+  }
+};

--- a/lib/schemePunkPluginLoader.js
+++ b/lib/schemePunkPluginLoader.js
@@ -75,6 +75,10 @@ const schemePunkPlugins = {
       defaultPluginRequireDirectory.source.originalSchemeSource(
         superConfig.source
       ),
+    activeSchemeSource:
+        defaultPluginRequireDirectory.source.activeSchemeSource(
+          superConfig.source
+        ),
     jsonTemplateFileSource:
       defaultPluginRequireDirectory.source.jsonTemplateFileSource(
         superConfig.source

--- a/test/activeSchemeSource.js
+++ b/test/activeSchemeSource.js
@@ -1,0 +1,70 @@
+'use strict';
+
+// Require mixin.
+const ActiveSchemeSource = require('../lib/plugins/source/activeSchemeSource');
+
+// Test scheme.
+const scheme = {
+  activeScheme: {
+    test1: 'thing',
+    test2: 'thing2',
+    test3: 'thing3'
+  }
+};
+
+// A super class.
+const tester = class {
+  constructor() {
+    this.scheme = scheme;
+  }
+};
+
+// A second super class with an setOrigin Implemented.
+const tester2 = class {
+  constructor() {
+    this.scheme = scheme;
+  }
+  setOrigin(originValue) {
+    this.retrievedOrigin = Object.keys(originValue);
+  }
+};
+
+// Create implementing class with mixin for first case.
+const One = class SchemePunkSchemeSourceTest extends ActiveSchemeSource(tester) {};
+
+const objTest = new One();
+
+// Create implementing class with mixin for second case.
+const Two = class SchemePunkSchemeSourceTest2 extends ActiveSchemeSource(tester2) {
+  setOrigin(passedValue) {
+    super.setOrigin(passedValue);
+  }
+};
+
+const objTest2 = new Two();
+
+// console.log(schemePunkTransform.constructor.name);
+
+module.exports = {
+  retrieveOrigin: (test) => {
+    objTest.setOrigin();
+    test.deepEqual(
+      objTest.retrievedOrigin,
+      {
+        test1: 'thing',
+        test2: 'thing2',
+        test3: 'thing3'
+      }
+
+    );
+    test.done();
+  },
+  retrieveOriginCallSuper: (test) => {
+    objTest2.setOrigin();
+    test.deepEqual(
+      objTest2.retrievedOrigin,
+      ['test1', 'test2', 'test3']
+    );
+    test.done();
+  }
+};

--- a/test/schemePunkConfigNoPlugins.js
+++ b/test/schemePunkConfigNoPlugins.js
@@ -24,7 +24,7 @@ module.exports = {
     );
     test.deepEqual(
       Object.keys(schemePunkConfig.sourcePlugins).length,
-      2
+      3
     );
     test.deepEqual(
       Object.keys(schemePunkConfig.transformPlugins).length,

--- a/test/schemePunkLoaderConfigPlugins.js
+++ b/test/schemePunkLoaderConfigPlugins.js
@@ -42,7 +42,7 @@ module.exports = {
 
     test.deepEqual(
       Object.keys(schemePunkConfig.sourcePlugins).length,
-      3
+      4
     );
     test.deepEqual(
       Object.keys(schemePunkConfig.transformPlugins).length,

--- a/test/schemePunkLoaderNotExist.js
+++ b/test/schemePunkLoaderNotExist.js
@@ -22,7 +22,7 @@ module.exports = {
     );
     test.deepEqual(
       Object.keys(schemePunkConfig.sourcePlugins).length,
-      3
+      4
     );
     test.deepEqual(
       Object.keys(schemePunkConfig.transformPlugins).length,

--- a/test/schemePunkPluginLoader.js
+++ b/test/schemePunkPluginLoader.js
@@ -19,7 +19,7 @@ module.exports = {
     );
     test.deepEqual(
       Object.keys(schemePunkConfig.sourcePlugins).length,
-      2
+      3
     );
     test.deepEqual(
       Object.keys(schemePunkConfig.transformPlugins).length,


### PR DESCRIPTION
Allowing for active to be the source allows us to do multistep transformations that are not currently chainable, such as duplicate merge into destinations such as:
[1,2,3] & [-1,-2,-3] into [1,2,3,-1,-2,-3]