### PR TITLE
feat(tokenTemplateValues): use async fs.readFile

### DIFF
--- a/__tests__/plugins/source/__snapshots__/jsonTemplateFileSource.js.snap
+++ b/__tests__/plugins/source/__snapshots__/jsonTemplateFileSource.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`jsonTemplateFileSource Json Template file source set Origin. 1`] = `
+Object {
+  "description": Object {
+    "description": "A description for this resource.",
+    "type": "string",
+  },
+  "numberProperty": Object {
+    "description": "A number property on this entity.",
+    "exclusiveMinimum": true,
+    "minimum": 0,
+    "type": "integer",
+  },
+  "title": Object {
+    "description": "A title.",
+    "type": "string",
+  },
+}
+`;

--- a/__tests__/plugins/source/jsonTemplateFileSource.js
+++ b/__tests__/plugins/source/jsonTemplateFileSource.js
@@ -33,6 +33,9 @@ class sourceBase {
   getOrigin() {
     return this.retrievedOrigin;
   }
+  getCallPath() { // eslint-disable-line class-methods-use-this
+    return __dirname;
+  }
 }
 
 class sourceBase2 {
@@ -49,6 +52,9 @@ class sourceBase2 {
   }
   getOrigin() {
     return this.retrievedOrigin;
+  }
+  getCallPath() { // eslint-disable-line class-methods-use-this
+    return __dirname;
   }
 }
 
@@ -77,7 +83,7 @@ describe('jsonTemplateFileSource', () => {
     const source = new (JsonTemplateFileSource(sourceBase)); // eslint-disable-line new-parens
     mocks.push(jest.spyOn(sourceBase.prototype, 'setOrigin'));
     options = {
-      origin: '../../__tests__/__helpers__/schemes/sourceSchema.json',
+      origin: '../../__helpers__/schemes/sourceSchema.json',
       target: null
     };
     source.init(options, scheme, holdOvers);
@@ -88,7 +94,7 @@ describe('jsonTemplateFileSource', () => {
     expect.assertions(1);
     const source = new (JsonTemplateFileSource(sourceBase)); // eslint-disable-line new-parens
     options = {
-      origin: '../../__tests__/__helpers__/schemes/sourceSchema.json',
+      origin: '../../__helpers__/schemes/sourceSchema.json',
       target: null
     };
     source.init(options, scheme, holdOvers);
@@ -112,9 +118,9 @@ describe('jsonTemplateFileSource', () => {
   });
 
   test('Super call json origin.', () => {
-    expect.assertions(3);
+    expect.assertions(1);
     options = {
-      origin: '../../__tests__/__helpers__/schemes/sourceSchema.json',
+      origin: '../../__helpers__/schemes/sourceSchema.json',
       target: 'numberProperty'
     };
     const source = new (JsonTemplateFileSource(sourceBase2)); // eslint-disable-line new-parens
@@ -126,8 +132,6 @@ describe('jsonTemplateFileSource', () => {
       minimum: 0,
       exclusiveMinimum: true
     });
-    expect(source.getTraceIndex(0)).toEqual(0);
-    expect(source.getTraceIndex(2)).toEqual(1);
   });
 
   test('Super implementer', () => {
@@ -139,7 +143,7 @@ describe('jsonTemplateFileSource', () => {
       }
     };
     options = {
-      origin: '../../__tests__/__helpers__/schemes/sourceSchema.json',
+      origin: '../../__helpers__/schemes/sourceSchema.json',
       target: null
     };
     const source = new Two();

--- a/__tests__/plugins/transform/tokenTemplateValues.js
+++ b/__tests__/plugins/transform/tokenTemplateValues.js
@@ -42,14 +42,15 @@ describe('Token Template Values Tests', () => {
       testKey: 'item0',
       testKey2: 'item1'
     };
-    expect(tokenTemplateValues.transform(value)).toEqual('Dust template one name is testName, testKey is item0.');
+    return tokenTemplateValues.transform(value)
+      .then(tValue => expect(tValue).toEqual('Dust template one name is testName, testKey is item0.'));
   });
 
   test('Use a template and replace with passed values using named replacement.', () => {
     tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template using tokens.
     tokenTemplateValues.options = {
-      origin: './../../__tests__/__helpers__/templates/templateLiteralTestTwo.tpl',
+      origin: './../../../__tests__/__helpers__/templates/templateLiteralTestTwo.tpl',
       named: true,
       json: false,
       unescape: false,
@@ -64,7 +65,8 @@ describe('Token Template Values Tests', () => {
       testKey: 'item0',
       testKey2: 'item1'
     };
-    expect(tokenTemplateValues.transform(value)).toEqual('Dust template one name is: testName, test has the value of testKey2: item1.');
+    return tokenTemplateValues.transform(value)
+      .then(tValue => expect(tValue).toEqual('Dust template one name is: testName, test has the value of testKey2: item1.'));
   });
 
   test('Trace index test', () => {
@@ -77,7 +79,7 @@ describe('Token Template Values Tests', () => {
     tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template using tokens.
     tokenTemplateValues.options = {
-      origin: '../../__tests__/__helpers__/templates/templateLiteralTestThree.tpl',
+      origin: '../../../__tests__/__helpers__/templates/templateLiteralTestThree.tpl',
       named: true,
       json: false,
       unescape: false,
@@ -93,14 +95,15 @@ describe('Token Template Values Tests', () => {
       testKey: 'item0',
       testKey2: 'item1'
     };
-    expect(tokenTemplateValues.transform(value)).toEqual('Dust template one name is: toofer, test has the value of testKey2: item1.');
+    return tokenTemplateValues.transform(value)
+      .then(tValue => expect(tValue).toEqual('Dust template one name is: toofer, test has the value of testKey2: item1.'));
   });
 
   test('Use a template in JSON format with holdovers', () => {
     tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template using tokens.
     tokenTemplateValues.options = {
-      origin: '../../__tests__/__helpers__/templates/templateJson.tpl',
+      origin: '../../../__tests__/__helpers__/templates/templateJson.tpl',
       json: true,
       unescape: true,
       named: false,
@@ -116,21 +119,22 @@ describe('Token Template Values Tests', () => {
       testKey: 'item0',
       testKey2: 'item1'
     };
-    expect(tokenTemplateValues.transform(value)).toEqual({
-      test: 'testName',
-      item: 'item1',
-      thing: [
-        'one',
-        'two'
-      ]
-    });
+    return tokenTemplateValues.transform(value)
+      .then(tValue => expect(tValue).toEqual({
+        test: 'testName',
+        item: 'item1',
+        thing: [
+          'one',
+          'two'
+        ]
+      }));
   });
 
   test('Use a template but pass in an empty object for values and indicate that it should not render empty tokens.', () => {
     tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template.
     tokenTemplateValues.options = {
-      origin: '../../__tests__/__helpers__/templates/templateFour.tpl',
+      origin: '../../../__tests__/__helpers__/templates/templateFour.tpl',
       template: {
         renderEmptyTokens: false
       }
@@ -138,14 +142,15 @@ describe('Token Template Values Tests', () => {
 
     // Test case value.
     value = {};
-    expect(tokenTemplateValues.transform(value)).toEqual({});
+    return tokenTemplateValues.transform(value)
+      .then(tValue => expect(tValue).toEqual({}));
   });
 
   test('Use a template with text escapes but enforce unescaping.', () => {
     tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template.
     tokenTemplateValues.options = {
-      origin: '../../__tests__/__helpers__/templates/templateFour.tpl',
+      origin: '../../../__tests__/__helpers__/templates/templateFour.tpl',
       json: false,
       unescape: true,
       named: false,
@@ -161,14 +166,15 @@ describe('Token Template Values Tests', () => {
       testKey: 'item0',
       testKey2: 'item1'
     };
-    expect(tokenTemplateValues.transform(value)).toEqual('Dust template "one" name is: testName, test has the value of \"testKey2: item1.'); // eslint-disable-line no-useless-escape
+    return tokenTemplateValues.transform(value)
+      .then(tValue => expect(tValue).toEqual('Dust template "one" name is: testName, test has the value of \"testKey2: item1.')); // eslint-disable-line no-useless-escape
   });
 
   test('Use a template with a simple string value instead of an object.', () => {
     tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template.
     tokenTemplateValues.options = {
-      origin: '../../__tests__/__helpers__/templates/templateFive.tpl',
+      origin: '../../../__tests__/__helpers__/templates/templateFive.tpl',
       named: false,
       json: false,
       unescape: false
@@ -176,6 +182,7 @@ describe('Token Template Values Tests', () => {
 
     // Test case value.
     value = 'testBoogie';
-    expect(tokenTemplateValues.transform(value)).toEqual('this is a testBoogie');
+    return tokenTemplateValues.transform(value)
+      .then(tValue => expect(tValue).toEqual('this is a testBoogie'));
   });
 });

--- a/__tests__/plugins/transform/tokenTemplateValues.js
+++ b/__tests__/plugins/transform/tokenTemplateValues.js
@@ -15,23 +15,24 @@ class BaseXform {
   getHoldOvers() {
     return this.holdOvers;
   }
+  getCallPath() { // eslint-disable-line class-methods-use-this
+    return __dirname;
+  }
 }
-
-let tokenTemplateValues;
 
 let value;
 let mocks = [];
 
 describe('Token Template Values Tests', () => {
-  afterEach(() => {
+  beforeEach(() => {
     mocks.forEach(mock => mock.mockRestore());
     mocks = [];
   });
   test('Template only values', () => {
-    tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
+    const tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template.
     tokenTemplateValues.options = {
-      origin: './../../__tests__/__helpers__/templates/templateLiteralTestOne.tpl',
+      origin: './../../__helpers__/templates/templateLiteralTestOne.tpl',
       named: false,
       json: false,
       unescape: false
@@ -45,12 +46,18 @@ describe('Token Template Values Tests', () => {
     return tokenTemplateValues.transform(value)
       .then(tValue => expect(tValue).toEqual('Dust template one name is testName, testKey is item0.'));
   });
+});
 
+describe('Use a template and replace with passed values using named replacement', () => {
+  beforeEach(() => {
+    mocks.forEach(mock => mock.mockRestore());
+    mocks = [];
+  });
   test('Use a template and replace with passed values using named replacement.', () => {
-    tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
+    const tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template using tokens.
     tokenTemplateValues.options = {
-      origin: './../../../__tests__/__helpers__/templates/templateLiteralTestTwo.tpl',
+      origin: './../../__helpers__/templates/templateLiteralTestTwo.tpl',
       named: true,
       json: false,
       unescape: false,
@@ -68,18 +75,18 @@ describe('Token Template Values Tests', () => {
     return tokenTemplateValues.transform(value)
       .then(tValue => expect(tValue).toEqual('Dust template one name is: testName, test has the value of testKey2: item1.'));
   });
+});
 
-  test('Trace index test', () => {
-    tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
-    // Set options for a template using tokens.
-    expect(tokenTemplateValues.getTraceIndex(1)).toEqual(0);
+describe('Use a template with passed values, named variables, and holdOvers.', () => {
+  beforeEach(() => {
+    mocks.forEach(mock => mock.mockRestore());
+    mocks = [];
   });
-
   test('Use a template with passed values, named variables, and holdOvers.', () => {
-    tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
+    const tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template using tokens.
     tokenTemplateValues.options = {
-      origin: '../../../__tests__/__helpers__/templates/templateLiteralTestThree.tpl',
+      origin: './../../__helpers__/templates/templateLiteralTestThree.tpl',
       named: true,
       json: false,
       unescape: false,
@@ -98,12 +105,18 @@ describe('Token Template Values Tests', () => {
     return tokenTemplateValues.transform(value)
       .then(tValue => expect(tValue).toEqual('Dust template one name is: toofer, test has the value of testKey2: item1.'));
   });
+});
 
+describe('Use a template in JSON format with holdovers', () => {
+  beforeEach(() => {
+    mocks.forEach(mock => mock.mockRestore());
+    mocks = [];
+  });
   test('Use a template in JSON format with holdovers', () => {
-    tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
+    const tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template using tokens.
     tokenTemplateValues.options = {
-      origin: '../../../__tests__/__helpers__/templates/templateJson.tpl',
+      origin: './../../__helpers__/templates/templateJson.tpl',
       json: true,
       unescape: true,
       named: false,
@@ -129,12 +142,18 @@ describe('Token Template Values Tests', () => {
         ]
       }));
   });
+});
 
+describe('Use a template but pass in an empty object for values and indicate that it should not render empty tokens.', () => {
+  beforeEach(() => {
+    mocks.forEach(mock => mock.mockRestore());
+    mocks = [];
+  });
   test('Use a template but pass in an empty object for values and indicate that it should not render empty tokens.', () => {
-    tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
+    const tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template.
     tokenTemplateValues.options = {
-      origin: '../../../__tests__/__helpers__/templates/templateFour.tpl',
+      origin: './../../__helpers__/templates/templateFour.tpl',
       template: {
         renderEmptyTokens: false
       }
@@ -145,12 +164,18 @@ describe('Token Template Values Tests', () => {
     return tokenTemplateValues.transform(value)
       .then(tValue => expect(tValue).toEqual({}));
   });
+});
 
+describe('Use a template with text escapes but enforce unescaping.', () => {
+  beforeEach(() => {
+    mocks.forEach(mock => mock.mockRestore());
+    mocks = [];
+  });
   test('Use a template with text escapes but enforce unescaping.', () => {
-    tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
+    const tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template.
     tokenTemplateValues.options = {
-      origin: '../../../__tests__/__helpers__/templates/templateFour.tpl',
+      origin: './../../__helpers__/templates/templateFour.tpl',
       json: false,
       unescape: true,
       named: false,
@@ -169,12 +194,18 @@ describe('Token Template Values Tests', () => {
     return tokenTemplateValues.transform(value)
       .then(tValue => expect(tValue).toEqual('Dust template "one" name is: testName, test has the value of \"testKey2: item1.')); // eslint-disable-line no-useless-escape
   });
+});
 
+describe('Use a template with a simple string value instead of an object.', () => {
+  beforeEach(() => {
+    mocks.forEach(mock => mock.mockRestore());
+    mocks = [];
+  });
   test('Use a template with a simple string value instead of an object.', () => {
-    tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
+    const tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template.
     tokenTemplateValues.options = {
-      origin: '../../../__tests__/__helpers__/templates/templateFive.tpl',
+      origin: './../../__helpers__/templates/templateFive.tpl',
       named: false,
       json: false,
       unescape: false

--- a/__tests__/plugins/transform/tokenTemplateValues.js
+++ b/__tests__/plugins/transform/tokenTemplateValues.js
@@ -217,3 +217,25 @@ describe('Use a template with a simple string value instead of an object.', () =
       .then(tValue => expect(tValue).toEqual('this is a testBoogie'));
   });
 });
+
+describe('No File.', () => {
+  beforeEach(() => {
+    mocks.forEach(mock => mock.mockRestore());
+    mocks = [];
+  });
+  test('Use a template with a simple string value instead of an object.', () => {
+    const tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
+    // Set options for a template.
+    tokenTemplateValues.options = {
+      origin: 'notther',
+      named: false,
+      json: false,
+      unescape: false
+    };
+
+    // Test case value.
+    value = 'testBoogie';
+    return tokenTemplateValues.transform(value)
+      .catch(err => expect(err.message).toContain('ENOENT:'));
+  });
+});

--- a/__tests__/plugins/transform/tokenTemplateValuesMockMustache.js
+++ b/__tests__/plugins/transform/tokenTemplateValuesMockMustache.js
@@ -56,7 +56,9 @@ describe('Token Template Values Tests', () => {
       testKey: 'item0',
       testKey2: 'item1'
     };
-    tokenTemplateValues.transform(value);
-    expect(mustache.render).toHaveBeenCalled();
+    return tokenTemplateValues.transform(value)
+      .then(() => {
+        expect(mustache.render).toHaveBeenCalled();
+      });
   });
 });

--- a/__tests__/plugins/transform/tokenTemplateValuesMockMustache.js
+++ b/__tests__/plugins/transform/tokenTemplateValuesMockMustache.js
@@ -19,9 +19,10 @@ class BaseXform {
   getHoldOvers() {
     return this.holdOvers;
   }
+  getCallPath() { // eslint-disable-line class-methods-use-this
+    return __dirname;
+  }
 }
-
-let tokenTemplateValues;
 
 let value;
 let mocks = [];
@@ -33,14 +34,14 @@ describe('Token Template Values Tests', () => {
   });
 
   test('Use a template in JSON format mustache spied', () => {
-    tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
+    const tokenTemplateValues = new (TokenTemplateValues(BaseXform))();
     // Set options for a template using tokens.
     jest.spyOn(mustache, 'render')
       .mockReturnValueOnce(false)
       .mockReturnValueOnce('');
     mocks.push(mustache.render);
     tokenTemplateValues.options = {
-      origin: '../../__tests__/__helpers__/templates/templateJson.tpl',
+      origin: '../../__helpers__/templates/templateJson.tpl',
       json: true,
       unescape: true,
       named: false,

--- a/__tests__/supers/destination.js
+++ b/__tests__/supers/destination.js
@@ -33,10 +33,11 @@ describe('Scheme Punk Destination Super', () => {
       otherProp: 'otherValue'
     };
 
+    const callPath = './';
     schemePunkDestination2 = new SchemePunkDestination();
-    schemePunkDestination2.init(options, scheme, holdOvers);
+    schemePunkDestination2.init(options, '', scheme, holdOvers, callPath);
     schemePunkDestination3 = new SchemePunkDestination();
-    schemePunkDestination3.init(options, scheme, holdOvers2);
+    schemePunkDestination3.init(options, '', scheme, holdOvers2, callPath);
   });
 
   afterAll(() => {
@@ -55,6 +56,12 @@ describe('Scheme Punk Destination Super', () => {
     schemePunkDestination.setDestination();
     return expect(schemePunkDestination.getDestination())
       .toEqual('activeScheme');
+  });
+
+  test('getCallPath', () => {
+    expect.assertions(1);
+    expect(schemePunkDestination2.getCallPath())
+      .toEqual('./');
   });
 
   // set/get value

--- a/__tests__/supers/source.js
+++ b/__tests__/supers/source.js
@@ -32,11 +32,11 @@ describe('Scheme Punk Source Super', () => {
     const holdOvers2 = {
       otherProp: 'otherValue'
     };
-
+    const callPath = './';
     schemePunkSource2 = new SchemePunkSource();
-    schemePunkSource2.init(options, scheme, holdOvers);
+    schemePunkSource2.init(options, scheme, holdOvers, callPath);
     schemePunkSource3 = new SchemePunkSource();
-    schemePunkSource3.init(options, scheme, holdOvers2);
+    schemePunkSource3.init(options, scheme, holdOvers2, callPath);
   });
 
   afterAll(() => {
@@ -56,6 +56,12 @@ describe('Scheme Punk Source Super', () => {
     schemePunkSource.getSchemePunkSourceTarget()
       .then(source => expect(source)
         .toEqual('test'));
+  });
+
+  test('getCallPath', () => {
+    expect.assertions(1);
+    expect(schemePunkSource2.getCallPath())
+      .toEqual('./');
   });
 
   test('getSource', () => {

--- a/__tests__/supers/transform.js
+++ b/__tests__/supers/transform.js
@@ -32,7 +32,7 @@ describe('Scheme Punk Transform Super', () => {
     };
 
     schemePunkTransform2 = new SchemePunkTransform();
-    schemePunkTransform2.init(options, holdOvers);
+    schemePunkTransform2.init(options, holdOvers, './');
     schemePunkTransform3 = new SchemePunkTransform();
     schemePunkTransform3.init(options, holdOvers2);
   });
@@ -73,6 +73,12 @@ describe('Scheme Punk Transform Super', () => {
     expect.assertions(1);
     return expect(schemePunkTransform.transform('transformTest'))
       .toEqual('transformTest');
+  });
+
+  test('call ', () => {
+    expect.assertions(1);
+    expect(schemePunkTransform2.getCallPath())
+      .toEqual('./');
   });
 
   test('get transform', () => {

--- a/lib/destination/schemePunkDestination.js
+++ b/lib/destination/schemePunkDestination.js
@@ -16,8 +16,8 @@ module.exports = function destinationFactory(pluginName) {
   }
 
   return setUp.then(extendedClass => class schemePunkDestination extends extendedClass {
-    init(options, transformedValue, scheme, holdOvers) {
-      return super.init(options, transformedValue, scheme, holdOvers);
+    init(options, transformedValue, scheme, holdOvers, callPath) {
+      return super.init(options, transformedValue, scheme, holdOvers, callPath);
     }
     /**
      * Here for mixins.

--- a/lib/destination/schemePunkDestination.js
+++ b/lib/destination/schemePunkDestination.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const molotov = require('../molotov')();
+const Molotov = require('../molotov');
 
-module.exports = function destinationFactory(pluginName) {
+module.exports = function destinationFactory(pluginName, molotovConfig) { // eslint-disable-line max-len
   let setUp;
-
+  const molotov = Molotov(molotovConfig);
   if (pluginName) {
     setUp = molotov.getMolotov() // Ensures we get any superOverrides from config.
       .then(pluginMaker => pluginMaker.resolve())

--- a/lib/molotov.js
+++ b/lib/molotov.js
@@ -38,12 +38,21 @@ const molotovNameSpace = 'schemePunk';
 // to use or extend your plugins with their cocktail classes.
 
 const SchemePunkMolotov = class extends Molotov {
-  constructor(configs) {
-    super(molotovPath, molotovNameSpace, supers, plugins);
+  constructor(configs, dynamicPlugs) {
+    super(molotovPath, molotovNameSpace, supers, plugins, dynamicPlugs);
     this.configs = configs;
   }
 };
 
-module.exports = function schemePunkMolotov(configs) {
-  return new SchemePunkMolotov(configs);
+/**
+ * SchemePunkMolotov Factory.
+ * @param {Object} options
+ *   Options for the schemePunkMolotov.
+ * @param {Object} options.config
+ *   Pass in a configuration object from a schemePunk implementing module for cocktail overrides.
+ * @param {Object} options.dynamicPlugs
+ *   Pass in dynamic plugin creations.
+ */
+module.exports = function schemePunkMolotov(molotovConfig = {config: {}, dynamicPlugins: {}}) {
+  return new SchemePunkMolotov(molotovConfig.config, molotovConfig.dynamicPlugins);
 };

--- a/lib/molotov.js
+++ b/lib/molotov.js
@@ -1,15 +1,12 @@
 'use strict';
 
-// Using config module with this module's default config.
-const requireDirectory = require('require-directory');
-
 // require the directory with all of your supers classes.
 // THe directory will be organized with directories representing
 // super name spaces
 // and those directories will hold your supers classes.
 //  supersDirectory
 //  |-- exampleSuperNameSpace.js
-const supers = requireDirectory(module, './supers');
+const supers = require('./supers');
 
 // require the directory with all of your mixins.
 // THe directory will be organized with directories representing
@@ -19,7 +16,7 @@ const supers = requireDirectory(module, './supers');
 //  |-- exampleSupersNameSpace
 //  |-- | -- mixinOne.js
 //  |-- | -- mixinTwo.js
-const plugins = requireDirectory(module, './plugins');
+const plugins = require('./plugins');
 
 // set the path to your .molotov.json molotov config file
 // (see above) from your

--- a/lib/molotov.js
+++ b/lib/molotov.js
@@ -46,10 +46,11 @@ const SchemePunkMolotov = class extends Molotov {
 
 /**
  * SchemePunkMolotov Factory.
- * @param {Object} options
+ * @param {Object} molotovConfig
  *   Options for the schemePunkMolotov.
  * @param {Object} options.config
- *   Pass in a configuration object from a schemePunk implementing module for cocktail overrides.
+ *   Pass in a configuration object from a schemePunk implementing module for
+ *   cocktail overrides.
  * @param {Object} options.dynamicPlugs
  *   Pass in dynamic plugin creations.
  */

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const concatIntoDestination = require('./destination/concatIntoDestination');
+const destroyDestination = require('./destination/destroyDestination');
+const mergeIntoDestination = require('./destination/mergeIntoDestination');
+const pushDestination = require('./destination/pushDestination');
+const activeSchemeSource = require('./source/activeSchemeSource');
+const jsonTemplateFileSource = require('./source/jsonTemplateFileSource');
+const originalSchemeSource = require('./source/originalSchemeSource');
+const appendValues = require('./transform/appendValues');
+const delimitValues = require('./transform/delimitValues');
+const filterAttributes = require('./transform/filterAttributes');
+const objectKeysTransform = require('./transform/objectKeysTransform');
+const prependValues = require('./transform/prependValues');
+const regexWordBoundariesValues = require('./transform/regexWordBoundariesValues');
+const tokenTemplateValues = require('./transform/tokenTemplateValues');
+const typeAdapter = require('./transform/typeAdapter');
+
+const plugins = {
+  destination: {
+    concatIntoDestination,
+    destroyDestination,
+    mergeIntoDestination,
+    pushDestination
+  },
+  source: {
+    activeSchemeSource,
+    jsonTemplateFileSource,
+    originalSchemeSource
+  },
+  transform: {
+    appendValues,
+    delimitValues,
+    filterAttributes,
+    objectKeysTransform,
+    prependValues,
+    regexWordBoundariesValues,
+    tokenTemplateValues,
+    typeAdapter
+  }
+};
+
+module.exports = plugins;

--- a/lib/plugins/source/jsonTemplateFileSource.js
+++ b/lib/plugins/source/jsonTemplateFileSource.js
@@ -4,7 +4,6 @@ const fs = require('fs-extra');
 const path = require('path');
 
 const _ = require('lodash');
-const stack = require('callsite');
 
 // eslint-disable-next-line max-len
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getTraceIndex"] }] */
@@ -22,15 +21,9 @@ module.exports = superclass => class extends superclass {
    */
   setOrigin(value) {
     // Use callsite to resolve path from calling script.
-    const base = require.resolve('../../../');
-    const stackTrace = stack().reverse();
-    let traceIndex = stackTrace
-      .findIndex(trace => trace.getFileName() === base);
-    traceIndex = this.getTraceIndex(traceIndex);
-
     this.retrievedOrigin = fs
       .readJsonSync(path.resolve(
-        path.dirname(stackTrace[traceIndex].getFileName()),
+        this.getCallPath(),
         value
       ));
     if (super.setOrigin) super.setOrigin(this.retrievedOrigin);
@@ -47,13 +40,5 @@ module.exports = superclass => class extends superclass {
       return _.get(this.getOrigin(), this.getSchemePunkSourceTarget());
     }
     return this.getOrigin();
-  }
-
-  getTraceIndex(index) {
-    if (index > 0) {
-      return index - 1;
-    }
-
-    return 0;
   }
 };

--- a/lib/plugins/source/jsonTemplateFileSource.js
+++ b/lib/plugins/source/jsonTemplateFileSource.js
@@ -3,8 +3,6 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-const _ = require('lodash');
-
 // eslint-disable-next-line max-len
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getTraceIndex"] }] */
 
@@ -19,26 +17,34 @@ module.exports = superclass => class extends superclass {
   /**
    * Function to set a file containing an object template as the source.
    */
+
+
   setOrigin(value) {
-    // Use callsite to resolve path from calling script.
-    this.retrievedOrigin = fs
-      .readJsonSync(path.resolve(
-        this.getCallPath(),
-        value
-      ));
+    this.retrievedOrigin = fs.readJson(path.resolve(
+      this.getCallPath(),
+      value
+    ))
+      .then((packageObj) => {
+        this.retrievedOrigin = packageObj;
+        return packageObj;
+      });
+
     if (super.setOrigin) super.setOrigin(this.retrievedOrigin);
   }
 
   /**
    * getSource gets the source for schemePunk based on our origin and target.
    *
-   * @return source
+   * @return {Promise} source
    *    Gets the target from the origin.
    */
   getSource() {
-    if (this.getSchemePunkSourceTarget()) {
-      return _.get(this.getOrigin(), this.getSchemePunkSourceTarget());
-    }
-    return this.getOrigin();
+    return this.getSchemePunkSourceTarget()
+      .then((target) => {
+        if (target) {
+          return super.getSource();
+        }
+        return this.getOrigin();
+      });
   }
 };

--- a/lib/plugins/transform/tokenTemplateValues.js
+++ b/lib/plugins/transform/tokenTemplateValues.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs-extra');
 const path = require('path');
-const stack = require('callsite');
 const mustache = require('mustache');
 const _ = require('lodash');
 
@@ -70,7 +69,10 @@ module.exports = superclass => class extends superclass {
       // we are not using tokens.
       tokens = Object.assign({}, tokens, tmpValue);
     }
-    const templatePath = this.getTemplatePath(this.options.origin);
+    const templatePath = path.resolve(
+      this.getCallPath(),
+      this.options.origin
+    );
 
     return new Promise((resolve, reject) => {
       fs.readFile(templatePath, 'utf-8', (err, file) => {
@@ -97,26 +99,5 @@ module.exports = superclass => class extends superclass {
 
         return super.transform(mustache.render(tmpFile, tokens));
       });
-  }
-
-  getTemplatePath(value) {
-    // Use callsite to resolve path from calling script.
-    const base = require.resolve('../../../');
-    const stackTrace = stack().reverse();
-    let traceIndex = stackTrace
-      .findIndex(trace => trace.getFileName() === base);
-    traceIndex = this.getTraceIndex(traceIndex);
-
-    return path.resolve(
-      path.dirname(stackTrace[traceIndex].getFileName()),
-      value
-    );
-  }
-
-  getTraceIndex(index) {
-    if (index > 0) {
-      return index - 1;
-    }
-    return 0;
   }
 };

--- a/lib/plugins/transform/tokenTemplateValues.js
+++ b/lib/plugins/transform/tokenTemplateValues.js
@@ -72,23 +72,31 @@ module.exports = superclass => class extends superclass {
     }
     const templatePath = this.getTemplatePath(this.options.origin);
 
-    const tmpFile = fs.readFileSync(templatePath, 'utf-8').replace(/\\"/g, '"');
+    return new Promise((resolve, reject) => {
+      fs.readFile(templatePath, 'utf-8', (err, file) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve(file.replace(/\\"/g, '"'));
+      });
+    })
+      .then((tmpFile) => {
+        if (_.isEmpty(tokens) && !_.get(this.options, 'template.renderEmptyTokens', true)) {
+          return super.transform({});
+        }
 
-    if (_.isEmpty(tokens) && !_.get(this.options, 'template.renderEmptyTokens', true)) {
-      return super.transform({});
-    }
+        if (this.options.json) {
+          if (mustache.render(tmpFile, tokens)) {
+            return super.transform(JSON.parse(mustache.render(tmpFile, tokens)));
+          }
+        }
 
-    if (this.options.json) {
-      if (mustache.render(tmpFile, tokens)) {
-        return super.transform(JSON.parse(mustache.render(tmpFile, tokens)));
-      }
-    }
+        if (this.options.unescape) {
+          return super.transform(mustache.render(tmpFile, tokens).replace(/\\"/g, '"'));
+        }
 
-    if (this.options.unescape) {
-      return super.transform(mustache.render(tmpFile, tokens).replace(/\\"/g, '"'));
-    }
-
-    return super.transform(mustache.render(tmpFile, tokens));
+        return super.transform(mustache.render(tmpFile, tokens));
+      });
   }
 
   getTemplatePath(value) {
@@ -112,4 +120,3 @@ module.exports = superclass => class extends superclass {
     return 0;
   }
 };
-

--- a/lib/plugins/transform/tokenTemplateValues.js
+++ b/lib/plugins/transform/tokenTemplateValues.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs-extra');
+const fs = require('fs');
 const path = require('path');
 const mustache = require('mustache');
 const _ = require('lodash');

--- a/lib/schemePunk.js
+++ b/lib/schemePunk.js
@@ -5,10 +5,11 @@ const schemePunkSourceBase = require('./source/schemePunkSource');
 const schemePunkDestinationBase = require('./destination/schemePunkDestination');
 
 module.exports = class schemePunk {
-  constructor(options) {
+  constructor(options, molotovConfig = {config: {}, dynamicPlugins: {}}) {
     this.options = options;
     this.holdOvers = {};
     this.callPath = __dirname;
+    this.molotovConfig = molotovConfig;
     if (options.holdOvers) {
       this.holdOvers = Object.assign({}, options.holdOvers);
     }
@@ -51,7 +52,7 @@ module.exports = class schemePunk {
    *
    */
   enhance(schemePunkScheme) {
-    return schemePunkSourceBase(this.options.source.plugin)
+    return schemePunkSourceBase(this.options.source.plugin, this.molotovConfig)
       .then((SchemeSource) => {
         const holdOvers = Object.assign({}, this.holdOvers);
         // Create a new schemePunk factory.
@@ -68,7 +69,7 @@ module.exports = class schemePunk {
         return this.getSchemeSource().getSource();
       })
       .then(source => Promise.all([
-        schemePunkTransformBase(this.options.transform.plugin),
+        schemePunkTransformBase(this.options.transform.plugin, this.molotovConfig),
         source
       ]))
       .then(([SchemeTransformer, source]) => {
@@ -86,7 +87,7 @@ module.exports = class schemePunk {
         const transformedValue = transformer.getTransformedValue();
 
         // Get Scheme.
-        const SchemeDestination = schemePunkDestinationBase(this.options.destination);
+        const SchemeDestination = schemePunkDestinationBase(this.options.destination, this.molotovConfig);
         const schemeDestination = new SchemeDestination();
         return schemeDestination.init(
           this.options.destination,

--- a/lib/schemePunk.js
+++ b/lib/schemePunk.js
@@ -87,7 +87,7 @@ module.exports = class schemePunk {
         const transformedValue = transformer.getTransformedValue();
 
         // Get Scheme.
-        const SchemeDestination = schemePunkDestinationBase(this.options.destination, this.molotovConfig);
+        const SchemeDestination = schemePunkDestinationBase(this.options.destination, this.molotovConfig); // eslint-disable-line max-len
         const schemeDestination = new SchemeDestination();
         return schemeDestination.init(
           this.options.destination,

--- a/lib/schemePunk.js
+++ b/lib/schemePunk.js
@@ -8,8 +8,12 @@ module.exports = class schemePunk {
   constructor(options) {
     this.options = options;
     this.holdOvers = {};
+    this.callPath = __dirname;
     if (options.holdOvers) {
       this.holdOvers = Object.assign({}, options.holdOvers);
+    }
+    if (options.callPath) {
+      this.callPath = options.callPath;
     }
   }
 
@@ -55,7 +59,8 @@ module.exports = class schemePunk {
         return schemeSource.init(
           this.options.source,
           schemePunkScheme,
-          holdOvers
+          holdOvers,
+          this.callPath
         );
       })
       .then((source) => {
@@ -70,7 +75,8 @@ module.exports = class schemePunk {
         const transformer = new SchemeTransformer();
         return Promise.all(transformer.init(
           this.options.transform,
-          this.getSchemeSource().getHoldOvers()
+          this.getSchemeSource().getHoldOvers(),
+          this.callPath
         ), source);
       })
       .then((transformer, source) => transformer.transform(source)
@@ -86,7 +92,8 @@ module.exports = class schemePunk {
           this.options.destination,
           transformedValue,
           schemePunkScheme,
-          transformer.getHoldOvers()
+          transformer.getHoldOvers(),
+          this.callPath
         );
       })
       .then(schemeDestination => schemeDestination.writeDestinationTarget()

--- a/lib/source/schemePunkSource.js
+++ b/lib/source/schemePunkSource.js
@@ -32,8 +32,8 @@ module.exports = function sourceFactory(pluginName) {
      *  Holdover values set in source that carry through to destination.
      *
      */
-      init(options, scheme, holdOvers) {
-        return super.init(options, scheme, holdOvers);
+      init(options, scheme, holdOvers, callPath) {
+        return super.init(options, scheme, holdOvers, callPath);
       }
       /**
        * Function to tranform a value, this is an implementing class and thus

--- a/lib/source/schemePunkSource.js
+++ b/lib/source/schemePunkSource.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const molotov = require('../molotov')();
+const Molotov = require('../molotov');
 
-function setUpPromise(pluginName) {
+function setUpPromise(pluginName, molotovConfig) {
   let setUp;
-
+  const molotov = Molotov(molotovConfig);
   if (pluginName) {
     setUp = molotov.getMolotov() // Ensures we get any superOverrides from config.
       .then(pluginMaker => pluginMaker.resolve())
@@ -18,8 +18,8 @@ function setUpPromise(pluginName) {
   return setUp;
 }
 
-module.exports = function sourceFactory(pluginName) {
-  return setUpPromise(pluginName)
+module.exports = function sourceFactory(pluginName, molotovOptions = {config: {}, dynamicPlugins: {}}) { // eslint-disable-line max-len
+  return setUpPromise(pluginName, molotovOptions)
     .then(extendedClass => class schemePunkSource extends extendedClass {
     /**
      * init function for schemePunkSource.

--- a/lib/supers/destination.js
+++ b/lib/supers/destination.js
@@ -18,7 +18,7 @@ module.exports = class destinationSuperBase {
    * @param {string} callPath - The path prefix you would like schemePunk to use
    *   when working with any schemes that have path origins or parameters.
    */
-  init(options, transformedValue, scheme, holdOvers, callPath) {
+  init(options, transformedValue, scheme, holdOvers, callPath = '') {
     // eslint-disable-next-line no-unused-vars
     this.scheme = scheme;
     this.setTarget(options.target);

--- a/lib/supers/destination.js
+++ b/lib/supers/destination.js
@@ -15,14 +15,17 @@ module.exports = class destinationSuperBase {
    * @param {*} transformedValue - A transformed target.
    * @param {Object} scheme - A destination scheme.
    * @param {Object} holdOvers - An object of holdovers.
+   * @param {string} callPath - The path prefix you would like schemePunk to use
+   *   when working with any schemes that have path origins or parameters.
    */
-  init(options, transformedValue, scheme, holdOvers) {
+  init(options, transformedValue, scheme, holdOvers, callPath) {
     // eslint-disable-next-line no-unused-vars
     this.scheme = scheme;
     this.setTarget(options.target);
     this.setDestination(options.destinationValue);
     this.setValue(transformedValue);
     this.setHoldOvers(holdOvers);
+    this.setCallPath(callPath);
     return Promise.resolve(this);
   }
 
@@ -140,5 +143,24 @@ module.exports = class destinationSuperBase {
    */
   getHoldOvers() {
     return this.holdOvers;
+  }
+
+  /**
+   * Sets the call path for the destination super.
+   *
+   * @param {string} callPath
+   *   A path to use as a prefix in any config passed paths.
+   */
+  setCallPath(callPath) {
+    this.callPath = callPath;
+  }
+  /**
+   * Gets the call path for the destination super.
+   *
+   *
+   * @returns {string} callPath
+   */
+  getCallPath() {
+    return this.callPath;
   }
 };

--- a/lib/supers/index.js
+++ b/lib/supers/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const destination = require('./destination');
+const source = require('./source');
+const transform = require('./transform');
+
+module.exports = {
+  destination,
+  source,
+  transform
+};

--- a/lib/supers/source.js
+++ b/lib/supers/source.js
@@ -126,4 +126,22 @@ module.exports = class sourceSuperBase {
   getHoldOvers() {
     return Promise.resolve(this.holdOvers);
   }
+  /**
+   * Sets the call path for the source super.
+   *
+   * @param {string} callPath
+   *   A path to use as a prefix in any config passed paths.
+   */
+  setCallPath(callPath) {
+    this.callPath = callPath;
+  }
+  /**
+   * Gets the call path for the source super.
+   *
+   *
+   * @returns {string} callPath
+   */
+  getCallPath() {
+    return this.callPath;
+  }
 };

--- a/lib/supers/source.js
+++ b/lib/supers/source.js
@@ -15,11 +15,14 @@ module.exports = class sourceSuperBase {
    *   A scheme punk scheme.
    * @param obj holdOvers
    *  Holdover values set in source that carry through to destination.
+   * @param {string} callPath
+   *  A callPath to use as a prefix with any path based origins.
    * @returns sourceSuperBase
    *  Returns and instance of the sourceSuperBase.
    */
-  init(options, scheme, holdOvers) {
+  init(options, scheme, holdOvers, callPath = '') {
     this.scheme = scheme;
+    this.setCallPath(callPath);
     this.setOrigin(options.origin);
     this.setTarget(options.target);
     this.setHoldOvers(holdOvers);

--- a/lib/supers/source.js
+++ b/lib/supers/source.js
@@ -23,7 +23,8 @@ module.exports = class sourceSuperBase {
     this.setOrigin(options.origin);
     this.setTarget(options.target);
     this.setHoldOvers(holdOvers);
-    return Promise.resolve(this);
+    return Promise.resolve(this.getOrigin())
+      .then(() => this);
   }
 
   /**

--- a/lib/supers/transform.js
+++ b/lib/supers/transform.js
@@ -6,8 +6,9 @@
  *
  */
 module.exports = class schemePunkTransform {
-  init(options, holdOvers) {
+  init(options, holdOvers, callPath = '') {
     this.options = options;
+    this.setCallPath(callPath);
     let holdOversCall = {};
     if (holdOvers) {
       holdOversCall = holdOvers;

--- a/lib/supers/transform.js
+++ b/lib/supers/transform.js
@@ -61,4 +61,22 @@ module.exports = class schemePunkTransform {
   getHoldOvers() {
     return Promise.resolve(this.holdOvers);
   }
+  /**
+   * Sets the call path for the transform super.
+   *
+   * @param {string} callPath
+   *   A path to use as a prefix in any config passed paths.
+   */
+  setCallPath(callPath) {
+    this.callPath = callPath;
+  }
+  /**
+   * Gets the call path for the transform super.
+   *
+   *
+   * @returns {string} callPath
+   */
+  getCallPath() {
+    return this.callPath;
+  }
 };

--- a/lib/transform/schemePunkTransform.js
+++ b/lib/transform/schemePunkTransform.js
@@ -1,9 +1,10 @@
 'use strict';
 
-const molotov = require('../molotov')();
+const Molotov = require('../molotov');
 
-module.exports = function transformFactory(pluginName) {
+module.exports = function transformFactory(pluginName, molotovConfig) {
   let setUp;
+  const molotov = Molotov(molotovConfig);
 
   if (pluginName) {
     setUp = molotov.getMolotov() // Ensures we get any superOverrides from config.

--- a/lib/transform/schemePunkTransform.js
+++ b/lib/transform/schemePunkTransform.js
@@ -16,8 +16,8 @@ module.exports = function transformFactory(pluginName) {
   }
 
   return setUp.then(extendedClass => class schemePunkTransform extends extendedClass {
-    init(schemeOptions, holdOvers) {
-      return super.init(schemeOptions, holdOvers);
+    init(schemeOptions, holdOvers, callPath) {
+      return super.init(schemeOptions, holdOvers, callPath);
     }
     /*
      * Function to tranform a value, this is an implementing class and thus

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jest-environment-node-debug": "^2.0.0",
     "npm-publish-git-tag": "^1.1.35",
     "npm-run-all": "^4.0.1",
+    "semantic-release": "^12.4.1",
     "semantic-release-github": "^3.1.2"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "jest-environment-node-debug": "^2.0.0",
     "npm-publish-git-tag": "^1.1.35",
     "npm-run-all": "^4.0.1",
-    "semantic-release": "^12.4.1",
     "semantic-release-github": "^3.1.2"
   },
   "config": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,76 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@octokit/rest@^14.0.3":
+  version "14.0.9"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-14.0.9.tgz#d5e0a00dcb78901dd7b2ef852acfc0aea7c479ef"
+  dependencies:
+    before-after-hook "^1.1.0"
+    debug "^3.1.0"
+    is-array-buffer "^1.0.0"
+    is-stream "^1.1.0"
+    lodash "^4.17.4"
+    url-template "^2.0.8"
+
+"@semantic-release/commit-analyzer@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-5.0.2.tgz#4db92f1aaed02397393ac78309892627c88eb64a"
+  dependencies:
+    conventional-changelog-angular "^1.4.0"
+    conventional-commits-parser "^2.0.0"
+    debug "^3.1.0"
+    import-from "^2.1.0"
+    lodash "^4.17.4"
+
+"@semantic-release/error@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-2.2.0.tgz#ee9d5a09c9969eade1ec864776aeda5c5cddbbf0"
+
+"@semantic-release/github@^3.0.1":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@semantic-release/github/-/github-3.0.3.tgz#a986fa36111a34b3cc42b1a7f41fe4f019df570b"
+  dependencies:
+    "@octokit/rest" "^14.0.3"
+    "@semantic-release/error" "^2.1.0"
+    debug "^3.1.0"
+    fs-extra "^5.0.0"
+    globby "^7.1.1"
+    lodash "^4.17.4"
+    mime "^2.0.3"
+    p-reduce "^1.0.0"
+    parse-github-url "^1.0.1"
+    url-join "^3.0.0"
+
+"@semantic-release/npm@^2.0.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@semantic-release/npm/-/npm-2.7.0.tgz#69d6b28c969c658458135eb8d725356c73a7320a"
+  dependencies:
+    "@semantic-release/error" "^2.1.0"
+    debug "^3.1.0"
+    execa "^0.9.0"
+    fs-extra "^5.0.0"
+    lodash "^4.17.4"
+    nerf-dart "^1.0.0"
+    normalize-url "^2.0.1"
+    npm-conf "^1.1.3"
+    npm-registry-client "^8.5.0"
+    read-pkg "^3.0.0"
+    registry-auth-token "^3.3.1"
+
+"@semantic-release/release-notes-generator@^6.0.0":
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/@semantic-release/release-notes-generator/-/release-notes-generator-6.0.6.tgz#c24c3cf6ad3d44e2453d55e5aaf63e0f091251d8"
+  dependencies:
+    conventional-changelog-angular "^1.4.0"
+    conventional-changelog-writer "^3.0.0"
+    conventional-commits-parser "^2.0.0"
+    debug "^3.1.0"
+    get-stream "^3.0.0"
+    git-url-parse "^8.0.0"
+    import-from "^2.1.0"
+    into-stream "^3.1.0"
+    lodash "^4.17.4"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -58,6 +128,13 @@ acorn@^5.0.0, acorn@^5.3.0:
 acorn@^5.1.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
+
+aggregate-error@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-1.0.0.tgz#888344dad0220a72e3af50906117f48771925fac"
+  dependencies:
+    clean-stack "^1.0.0"
+    indent-string "^3.0.0"
 
 ajv-keywords@^2.1.0:
   version "2.1.1"
@@ -130,6 +207,10 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   dependencies:
     color-convert "^1.9.0"
 
+ansicolors@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
+
 any-promise@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
@@ -163,6 +244,10 @@ argparse@^1.0.7:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
+
+argv-formatter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/argv-formatter/-/argv-formatter-1.0.0.tgz#a0ca0cbc29a5b73e836eebe1cbf6c5e0e4eb82f9"
 
 arr-diff@^2.0.0:
   version "2.0.0"
@@ -416,6 +501,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+before-after-hook@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.1.0.tgz#83165e15a59460d13702cb8febd6a1807896db5a"
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -483,6 +572,10 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+builtins@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
+
 cacheable-request@^2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"
@@ -520,6 +613,14 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
+camelcase-keys@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
+  dependencies:
+    camelcase "^4.1.0"
+    map-obj "^2.0.0"
+    quick-lru "^1.0.0"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
@@ -531,6 +632,13 @@ camelcase@^2.0.0:
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
+cardinal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cardinal/-/cardinal-1.0.0.tgz#50e21c1b0aa37729f9377def196b5a9cec932ee9"
+  dependencies:
+    ansicolors "~0.2.1"
+    redeyed "~1.0.0"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -561,7 +669,7 @@ chalk@^2.0.0, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chalk@^2.0.1:
+chalk@^2.0.1, chalk@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
   dependencies:
@@ -577,11 +685,21 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
+clean-stack@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-1.3.0.tgz#9e821501ae979986c46b1d66d2d432db2fd4ae31"
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
     restore-cursor "^2.0.0"
+
+cli-table@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
+  dependencies:
+    colors "1.0.3"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -635,11 +753,19 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
+colors@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
+
 combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^2.11.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
 
 commander@^2.9.0:
   version "2.11.0"
@@ -656,13 +782,20 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.10, concat-stream@^1.6.0:
+concat-stream@^1.4.10, concat-stream@^1.5.2, concat-stream@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+config-chain@^1.1.11:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.11.tgz#aba09747dfbe4c3e70e766a6e41586e1859fc6f2"
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
 
 config@^1.24.0, config@^1.25.1:
   version "1.28.1"
@@ -682,6 +815,13 @@ contains-path@^0.1.0:
 content-type-parser@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
+
+conventional-changelog-angular@^1.4.0:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz#b27f2b315c16d0a1f23eb181309d0e6a4698ea0f"
+  dependencies:
+    compare-func "^1.3.1"
+    q "^1.5.1"
 
 conventional-changelog-angular@^1.6.2, conventional-changelog-angular@^1.6.4:
   version "1.6.4"
@@ -761,6 +901,21 @@ conventional-changelog-preset-loader@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.4.tgz#5096165f2742a18dc0e33ff2ab9ee08dc9d77f08"
 
+conventional-changelog-writer@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-3.0.4.tgz#705b46a8b8277bd7fd79cad8032095b5d803864c"
+  dependencies:
+    compare-func "^1.3.1"
+    conventional-commits-filter "^1.1.5"
+    dateformat "^3.0.0"
+    handlebars "^4.0.2"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.2.1"
+    meow "^4.0.0"
+    semver "^5.5.0"
+    split "^1.0.0"
+    through2 "^2.0.0"
+
 conventional-changelog-writer@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-3.0.2.tgz#f3f934028379c0cab90aecfcaf009bf8a187ef14"
@@ -804,6 +959,13 @@ conventional-commits-detector@^0.1.1:
 conventional-commits-filter@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-1.1.3.tgz#5bf591bc4882fc8c9bd329e5a83ca1fa8721d9fb"
+  dependencies:
+    is-subset "^0.1.1"
+    modify-values "^1.0.0"
+
+conventional-commits-filter@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-1.1.5.tgz#77aac065e3de9c1a74b801e8e25c9affb3184f65"
   dependencies:
     is-subset "^0.1.1"
     modify-values "^1.0.0"
@@ -860,6 +1022,15 @@ core-js@^2.4.0, core-js@^2.5.0:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cosmiconfig@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+    require-from-string "^2.0.1"
 
 coveralls@^3.0.0:
   version "3.0.0"
@@ -942,7 +1113,14 @@ debug@^3.0.0, debug@^3.0.1, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
+decamelize-keys@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
+  dependencies:
+    decamelize "^1.1.0"
+    map-obj "^1.0.0"
+
+decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -1019,6 +1197,13 @@ diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
+dir-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -1045,6 +1230,12 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
+duplexer2@~0.1.0:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
+  dependencies:
+    readable-stream "^2.0.2"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -1058,6 +1249,13 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+env-ci@^1.0.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/env-ci/-/env-ci-1.4.1.tgz#e4c68257270155db202f6ca9c61f6520ac6bfeaa"
+  dependencies:
+    execa "^0.9.0"
+    java-properties "^0.2.9"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
@@ -1226,6 +1424,10 @@ esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
+esprima@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.0.0.tgz#53cf247acda77313e551c3aa2e73342d3fb4f7d9"
+
 esquery@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
@@ -1268,6 +1470,18 @@ exec-sh@^0.2.0:
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+execa@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -1573,6 +1787,17 @@ git-latest-semver-tag@^1.0.2:
     git-semver-tags "^1.1.2"
     meow "^3.3.0"
 
+git-log-parser@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/git-log-parser/-/git-log-parser-1.2.0.tgz#2e6a4c1b13fc00028207ba795a7ac31667b9fd4a"
+  dependencies:
+    argv-formatter "~1.0.0"
+    spawn-error-forwarder "~1.0.0"
+    split2 "~1.0.0"
+    stream-combiner2 "~1.1.1"
+    through2 "~2.0.0"
+    traverse "~0.6.6"
+
 git-raw-commits@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-0.1.2.tgz#2becbdcd3f96ef0b19f16863f7a2f6d9d8ab8369"
@@ -1606,6 +1831,19 @@ git-semver-tags@^1.0.0, git-semver-tags@^1.1.2, git-semver-tags@^1.3.2:
   dependencies:
     meow "^3.3.0"
     semver "^5.0.1"
+
+git-up@^2.0.0:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/git-up/-/git-up-2.0.10.tgz#20fe6bafbef4384cae253dc4f463c49a0c3bd2ec"
+  dependencies:
+    is-ssh "^1.3.0"
+    parse-url "^1.3.0"
+
+git-url-parse@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-8.1.0.tgz#d1ee09213efce5d8dc7a21bb03f17cfe0c111122"
+  dependencies:
+    git-up "^2.0.0"
 
 gitconfiglocal@^1.0.0:
   version "1.0.0"
@@ -1651,6 +1889,17 @@ globby@^5.0.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
 
 got@^7.0.0:
   version "7.1.0"
@@ -1804,7 +2053,11 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-hosted-git-info@^2.1.4:
+hook-std@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/hook-std/-/hook-std-0.4.0.tgz#fa8b2f84d358763137cb7d17e3308b28714bd174"
+
+hosted-git-info@^2.1.4, hosted-git-info@^2.4.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
@@ -1846,9 +2099,15 @@ iconv-lite@0.4.19, iconv-lite@^0.4.17:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-ignore@^3.3.3:
+ignore@^3.3.3, ignore@^3.3.5:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+
+import-from@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-from/-/import-from-2.1.0.tgz#335db7f2a7affd53aaa471d4b8021dee36b7f3b1"
+  dependencies:
+    resolve-from "^3.0.0"
 
 import-local@^1.0.0:
   version "1.0.0"
@@ -1867,6 +2126,10 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -1878,7 +2141,7 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, 
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-ini@^1.3.2, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
@@ -1922,6 +2185,10 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
+is-array-buffer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-1.0.0.tgz#f32497a0509d109423f472003f98bab6a8ea34cb"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -1949,6 +2216,10 @@ is-ci@^1.0.10:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -2067,6 +2338,12 @@ is-scoped@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-scoped/-/is-scoped-1.0.0.tgz#449ca98299e713038256289ecb2b540dc437cb30"
   dependencies:
     scoped-regex "^1.0.0"
+
+is-ssh@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.3.0.tgz#ebea1169a2614da392a63740366c3ce049d8dff6"
+  dependencies:
+    protocols "^1.1.0"
 
 is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
@@ -2201,6 +2478,10 @@ isurl@^1.0.0-alpha5:
   dependencies:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
+
+java-properties@^0.2.9:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/java-properties/-/java-properties-0.2.10.tgz#2551560c25fa1ad94d998218178f233ad9b18f60"
 
 jest-changed-files@^22.2.0:
   version "22.2.0"
@@ -2461,7 +2742,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.6.1, js-yaml@^3.7.0, js-yaml@^3.9.1:
+js-yaml@^3.6.1, js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -2685,6 +2966,10 @@ lodash._root@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
 
+lodash.assign@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -2757,6 +3042,10 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
+lodash.toarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
+
 lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.7.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
@@ -2813,9 +3102,27 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+map-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
+
 map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+
+marked-terminal@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/marked-terminal/-/marked-terminal-2.0.0.tgz#5eaf568be66f686541afa52a558280310a31de2d"
+  dependencies:
+    cardinal "^1.0.0"
+    chalk "^1.1.3"
+    cli-table "^0.3.1"
+    lodash.assign "^4.2.0"
+    node-emoji "^1.4.1"
+
+marked@^0.3.9:
+  version "0.3.16"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.16.tgz#2f188b7dfcfa6540fe9940adaf0f3b791c9a5cba"
 
 mem@^1.1.0:
   version "1.1.0"
@@ -2843,6 +3150,20 @@ meow@^3.1.0, meow@^3.3.0:
     read-pkg-up "^1.0.1"
     redent "^1.0.0"
     trim-newlines "^1.0.0"
+
+meow@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-4.0.0.tgz#fd5855dd008db5b92c552082db1c307cba20b29d"
+  dependencies:
+    camelcase-keys "^4.0.0"
+    decamelize-keys "^1.0.0"
+    loud-rejection "^1.0.0"
+    minimist "^1.1.3"
+    minimist-options "^3.0.1"
+    normalize-package-data "^2.3.4"
+    read-pkg-up "^3.0.0"
+    redent "^2.0.0"
+    trim-newlines "^2.0.0"
 
 merge-stream@^1.0.1:
   version "1.0.1"
@@ -2882,6 +3203,10 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.33.0"
 
+mime@^2.0.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.2.0.tgz#161e541965551d3b549fa1114391e3a3d55b923b"
+
 mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
@@ -2895,6 +3220,13 @@ minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
     brace-expansion "^1.1.7"
+
+minimist-options@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954"
+  dependencies:
+    arrify "^1.0.1"
+    is-plain-obj "^1.1.0"
 
 minimist@0.0.8:
   version "0.0.8"
@@ -2949,6 +3281,16 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+nerf-dart@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nerf-dart/-/nerf-dart-1.0.0.tgz#e6dab7febf5ad816ea81cf5c629c5a0ebde72c1a"
+
+node-emoji@^1.4.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.8.1.tgz#6eec6bfb07421e2148c75c6bba72421f8530a826"
+  dependencies:
+    lodash.toarray "^4.4.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -2985,7 +3327,7 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5:
+normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5, "normalize-package-data@~1.0.1 || ^2.0.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   dependencies:
@@ -3004,13 +3346,29 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-url@2.0.1:
+normalize-url@2.0.1, normalize-url@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-2.0.1.tgz#835a9da1551fa26f70e92329069a23aa6574d7e6"
   dependencies:
     prepend-http "^2.0.0"
     query-string "^5.0.1"
     sort-keys "^2.0.0"
+
+npm-conf@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/npm-conf/-/npm-conf-1.1.3.tgz#256cc47bd0e218c259c4e9550bf413bc2192aff9"
+  dependencies:
+    config-chain "^1.1.11"
+    pify "^3.0.0"
+
+"npm-package-arg@^3.0.0 || ^4.0.0 || ^5.0.0":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-5.1.2.tgz#fb18d17bb61e60900d6312619919bd753755ab37"
+  dependencies:
+    hosted-git-info "^2.4.2"
+    osenv "^0.1.4"
+    semver "^5.1.0"
+    validate-npm-package-name "^3.0.0"
 
 npm-publish-git-tag@^1.1.35:
   version "1.1.35"
@@ -3024,6 +3382,23 @@ npm-publish-git-tag@^1.1.35:
     set-npm-auth-token-for-ci "^1.0.14"
     shelljs "^0.8.0"
     write-pkg "^3.0.1"
+
+npm-registry-client@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/npm-registry-client/-/npm-registry-client-8.5.0.tgz#4878fb6fa1f18a5dc08ae83acf94d0d0112d7ed0"
+  dependencies:
+    concat-stream "^1.5.2"
+    graceful-fs "^4.1.6"
+    normalize-package-data "~1.0.1 || ^2.0.0"
+    npm-package-arg "^3.0.0 || ^4.0.0 || ^5.0.0"
+    once "^1.3.3"
+    request "^2.74.0"
+    retry "^0.10.0"
+    semver "2 >=2.2.1 || 3.x || 4 || 5"
+    slide "^1.1.3"
+    ssri "^4.1.2"
+  optionalDependencies:
+    npmlog "2 || ^3.1.0 || ^4.0.0"
 
 npm-run-all@^4.0.1:
   version "4.1.1"
@@ -3045,7 +3420,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.0.2:
+"npmlog@2 || ^3.1.0 || ^4.0.0", npmlog@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   dependencies:
@@ -3165,6 +3540,14 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
+p-reduce@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
+
+p-reflect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-reflect/-/p-reflect-1.0.0.tgz#f4fa1ee1bb546d8eb3ec0321148dfe0a79137bb8"
+
 p-timeout@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-1.2.1.tgz#5eb3b353b7fce99f101a1038880bb054ebbea386"
@@ -3184,6 +3567,10 @@ p-try@^1.0.0:
 parse-github-repo-url@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz#9e7d8bb252a6cb6ba42595060b7bf6df3dbc1f50"
+
+parse-github-url@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-github-url/-/parse-github-url-1.0.2.tgz#242d3b65cbcdda14bb50439e3242acf6971db395"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -3206,6 +3593,13 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
+
+parse-url@^1.3.0:
+  version "1.3.11"
+  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-1.3.11.tgz#57c15428ab8a892b1f43869645c711d0e144b554"
+  dependencies:
+    is-ssh "^1.3.0"
+    protocols "^1.4.0"
 
 parse5@4.0.0:
   version "4.0.0"
@@ -3348,6 +3742,14 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
+
+protocols@^1.1.0, protocols@^1.4.0:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.6.tgz#f8bb263ea1b5fd7a7604d26b8be39bd77678bf8a"
+
 ps-tree@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
@@ -3386,6 +3788,10 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+quick-lru@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -3393,7 +3799,7 @@ randomatic@^1.1.3:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-rc@^1.0.1, rc@^1.1.7:
+rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.5.tgz#275cd687f6e3b36cc756baa26dfee80a790301fd"
   dependencies:
@@ -3415,6 +3821,13 @@ read-pkg-up@^2.0.0:
   dependencies:
     find-up "^2.0.0"
     read-pkg "^2.0.0"
+
+read-pkg-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^3.0.0"
 
 read-pkg@^1.0.0, read-pkg@^1.1.0:
   version "1.1.0"
@@ -3440,7 +3853,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
   dependencies:
@@ -3492,6 +3905,19 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
+redent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
+  dependencies:
+    indent-string "^3.0.0"
+    strip-indent "^2.0.0"
+
+redeyed@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-1.0.1.tgz#e96c193b40c0816b00aec842698e61185e55498a"
+  dependencies:
+    esprima "~3.0.0"
+
 regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
@@ -3501,6 +3927,13 @@ regex-cache@^0.4.2:
   resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
   dependencies:
     is-equal-shallow "^0.1.3"
+
+registry-auth-token@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
+  dependencies:
+    rc "^1.1.6"
+    safe-buffer "^5.0.1"
 
 registry-url@^3.1.0:
   version "3.1.0"
@@ -3567,7 +4000,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.79.0, request@^2.83.0:
+request@^2.74.0, request@^2.79.0, request@^2.83.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:
@@ -3598,6 +4031,10 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
+require-from-string@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
+
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -3623,6 +4060,10 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
@@ -3645,6 +4086,10 @@ restore-cursor@^2.0.0:
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
+
+retry@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -3674,7 +4119,7 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
@@ -3744,11 +4189,39 @@ semantic-release-github@^3.1.2:
     shifted-semver-increment "^1.0.3"
     stream-to-array "^2.3.0"
 
+semantic-release@^12.4.1:
+  version "12.4.1"
+  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-12.4.1.tgz#4faeee44fe7fbebbc7af8cc9e3522eb7877a0260"
+  dependencies:
+    "@semantic-release/commit-analyzer" "^5.0.0"
+    "@semantic-release/error" "^2.1.0"
+    "@semantic-release/github" "^3.0.1"
+    "@semantic-release/npm" "^2.0.0"
+    "@semantic-release/release-notes-generator" "^6.0.0"
+    aggregate-error "^1.0.0"
+    chalk "^2.3.0"
+    commander "^2.11.0"
+    cosmiconfig "^4.0.0"
+    debug "^3.1.0"
+    env-ci "^1.0.0"
+    execa "^0.9.0"
+    get-stream "^3.0.0"
+    git-log-parser "^1.2.0"
+    hook-std "^0.4.0"
+    lodash "^4.17.4"
+    marked "^0.3.9"
+    marked-terminal "^2.0.0"
+    p-reduce "^1.0.0"
+    p-reflect "^1.0.0"
+    read-pkg-up "^3.0.0"
+    resolve-from "^4.0.0"
+    semver "^5.4.1"
+
 semver-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-1.0.0.tgz#92a4969065f9c70c694753d55248fc68f8f652c9"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.4.1:
+"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -3824,6 +4297,10 @@ slice-ansi@1.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
 
+slide@^1.1.3:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+
 sntp@1.x.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
@@ -3868,6 +4345,10 @@ source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
+spawn-error-forwarder@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz#1afd94738e999b0346d7b9fc373be55e07577029"
+
 spdx-correct@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
@@ -3893,6 +4374,12 @@ split2@^2.0.0:
   resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
   dependencies:
     through2 "^2.0.2"
+
+split2@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-1.0.0.tgz#52e2e221d88c75f9a73f90556e263ff96772b314"
+  dependencies:
+    through2 "~2.0.0"
 
 split@0.3:
   version "0.3.3"
@@ -3924,6 +4411,12 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+ssri@^4.1.2:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-4.1.6.tgz#0cb49b6ac84457e7bdd466cb730c3cb623e9a25b"
+  dependencies:
+    safe-buffer "^5.1.0"
+
 stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
@@ -3937,6 +4430,13 @@ stream-array@^1.1.2:
   resolved "https://registry.yarnpkg.com/stream-array/-/stream-array-1.1.2.tgz#9e5f7345f2137c30ee3b498b9114e80b52bb7eb5"
   dependencies:
     readable-stream "~2.1.0"
+
+stream-combiner2@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stream-combiner2/-/stream-combiner2-1.1.1.tgz#fb4d8a1420ea362764e21ad4780397bebcb41cbe"
+  dependencies:
+    duplexer2 "~0.1.0"
+    readable-stream "^2.0.2"
 
 stream-combiner@~0.0.4:
   version "0.0.4"
@@ -4165,9 +4665,17 @@ tr46@^1.0.0:
   dependencies:
     punycode "^2.1.0"
 
+traverse@~0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
+
+trim-newlines@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
 
 trim-off-newlines@^1.0.0:
   version "1.0.1"
@@ -4230,6 +4738,10 @@ universalify@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
+url-join@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-3.0.0.tgz#26e8113ace195ea30d0fc38186e45400f9cea672"
+
 url-parse-lax@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
@@ -4241,6 +4753,10 @@ url-parse-lax@^3.0.0:
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
   dependencies:
     prepend-http "^2.0.0"
+
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
 
 url-to-options@^1.0.1:
   version "1.0.1"
@@ -4273,6 +4789,12 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
+
+validate-npm-package-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
+  dependencies:
+    builtins "^1.0.3"
 
 verror@1.10.0:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3181,9 +3181,9 @@ modify-values@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.0.tgz#e2b6cdeb9ce19f99317a53722f3dbf5df5eaaab2"
 
-molotov@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/molotov/-/molotov-1.1.1.tgz#ddfc41c51b4a7a2e9d5d51424b2de5b92225ee4f"
+molotov@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/molotov/-/molotov-1.2.0.tgz#e6856825be1b90251e4b4e62f38793fc0ba97a20"
   dependencies:
     callsite "^1.0.0"
     config "^1.25.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,76 +16,6 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@octokit/rest@^14.0.3":
-  version "14.0.9"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-14.0.9.tgz#d5e0a00dcb78901dd7b2ef852acfc0aea7c479ef"
-  dependencies:
-    before-after-hook "^1.1.0"
-    debug "^3.1.0"
-    is-array-buffer "^1.0.0"
-    is-stream "^1.1.0"
-    lodash "^4.17.4"
-    url-template "^2.0.8"
-
-"@semantic-release/commit-analyzer@^5.0.0":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-5.0.2.tgz#4db92f1aaed02397393ac78309892627c88eb64a"
-  dependencies:
-    conventional-changelog-angular "^1.4.0"
-    conventional-commits-parser "^2.0.0"
-    debug "^3.1.0"
-    import-from "^2.1.0"
-    lodash "^4.17.4"
-
-"@semantic-release/error@^2.1.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-2.2.0.tgz#ee9d5a09c9969eade1ec864776aeda5c5cddbbf0"
-
-"@semantic-release/github@^3.0.1":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@semantic-release/github/-/github-3.0.3.tgz#a986fa36111a34b3cc42b1a7f41fe4f019df570b"
-  dependencies:
-    "@octokit/rest" "^14.0.3"
-    "@semantic-release/error" "^2.1.0"
-    debug "^3.1.0"
-    fs-extra "^5.0.0"
-    globby "^7.1.1"
-    lodash "^4.17.4"
-    mime "^2.0.3"
-    p-reduce "^1.0.0"
-    parse-github-url "^1.0.1"
-    url-join "^3.0.0"
-
-"@semantic-release/npm@^2.0.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@semantic-release/npm/-/npm-2.7.0.tgz#69d6b28c969c658458135eb8d725356c73a7320a"
-  dependencies:
-    "@semantic-release/error" "^2.1.0"
-    debug "^3.1.0"
-    execa "^0.9.0"
-    fs-extra "^5.0.0"
-    lodash "^4.17.4"
-    nerf-dart "^1.0.0"
-    normalize-url "^2.0.1"
-    npm-conf "^1.1.3"
-    npm-registry-client "^8.5.0"
-    read-pkg "^3.0.0"
-    registry-auth-token "^3.3.1"
-
-"@semantic-release/release-notes-generator@^6.0.0":
-  version "6.0.6"
-  resolved "https://registry.yarnpkg.com/@semantic-release/release-notes-generator/-/release-notes-generator-6.0.6.tgz#c24c3cf6ad3d44e2453d55e5aaf63e0f091251d8"
-  dependencies:
-    conventional-changelog-angular "^1.4.0"
-    conventional-changelog-writer "^3.0.0"
-    conventional-commits-parser "^2.0.0"
-    debug "^3.1.0"
-    get-stream "^3.0.0"
-    git-url-parse "^8.0.0"
-    import-from "^2.1.0"
-    into-stream "^3.1.0"
-    lodash "^4.17.4"
-
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -128,13 +58,6 @@ acorn@^5.0.0, acorn@^5.3.0:
 acorn@^5.1.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
-
-aggregate-error@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-1.0.0.tgz#888344dad0220a72e3af50906117f48771925fac"
-  dependencies:
-    clean-stack "^1.0.0"
-    indent-string "^3.0.0"
 
 ajv-keywords@^2.1.0:
   version "2.1.1"
@@ -207,10 +130,6 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   dependencies:
     color-convert "^1.9.0"
 
-ansicolors@~0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
-
 any-promise@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
@@ -244,10 +163,6 @@ argparse@^1.0.7:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
-
-argv-formatter@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/argv-formatter/-/argv-formatter-1.0.0.tgz#a0ca0cbc29a5b73e836eebe1cbf6c5e0e4eb82f9"
 
 arr-diff@^2.0.0:
   version "2.0.0"
@@ -501,10 +416,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-before-after-hook@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.1.0.tgz#83165e15a59460d13702cb8febd6a1807896db5a"
-
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -572,10 +483,6 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
-builtins@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
-
 cacheable-request@^2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"
@@ -625,13 +532,6 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-cardinal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/cardinal/-/cardinal-1.0.0.tgz#50e21c1b0aa37729f9377def196b5a9cec932ee9"
-  dependencies:
-    ansicolors "~0.2.1"
-    redeyed "~1.0.0"
-
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -661,7 +561,7 @@ chalk@^2.0.0, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chalk@^2.0.1, chalk@^2.3.0:
+chalk@^2.0.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
   dependencies:
@@ -677,21 +577,11 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
-clean-stack@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-1.3.0.tgz#9e821501ae979986c46b1d66d2d432db2fd4ae31"
-
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
     restore-cursor "^2.0.0"
-
-cli-table@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
-  dependencies:
-    colors "1.0.3"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -745,19 +635,11 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
-colors@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
-
 combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
     delayed-stream "~1.0.0"
-
-commander@^2.11.0:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
 
 commander@^2.9.0:
   version "2.11.0"
@@ -774,20 +656,13 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.10, concat-stream@^1.5.2, concat-stream@^1.6.0:
+concat-stream@^1.4.10, concat-stream@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
-
-config-chain@^1.1.11:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.11.tgz#aba09747dfbe4c3e70e766a6e41586e1859fc6f2"
-  dependencies:
-    ini "^1.3.4"
-    proto-list "~1.2.1"
 
 config@^1.24.0, config@^1.25.1:
   version "1.28.1"
@@ -808,7 +683,7 @@ content-type-parser@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
 
-conventional-changelog-angular@^1.4.0, conventional-changelog-angular@^1.6.2, conventional-changelog-angular@^1.6.4:
+conventional-changelog-angular@^1.6.2, conventional-changelog-angular@^1.6.4:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.6.4.tgz#47debaf92b75b0bd6b39fcba8f9c70dd97552be6"
   dependencies:
@@ -886,7 +761,7 @@ conventional-changelog-preset-loader@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.4.tgz#5096165f2742a18dc0e33ff2ab9ee08dc9d77f08"
 
-conventional-changelog-writer@^3.0.0, conventional-changelog-writer@^3.0.2:
+conventional-changelog-writer@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-3.0.2.tgz#f3f934028379c0cab90aecfcaf009bf8a187ef14"
   dependencies:
@@ -985,15 +860,6 @@ core-js@^2.4.0, core-js@^2.5.0:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
-cosmiconfig@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
-  dependencies:
-    is-directory "^0.3.1"
-    js-yaml "^3.9.0"
-    parse-json "^4.0.0"
-    require-from-string "^2.0.1"
 
 coveralls@^3.0.0:
   version "3.0.0"
@@ -1153,13 +1019,6 @@ diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
-dir-glob@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
-  dependencies:
-    arrify "^1.0.1"
-    path-type "^3.0.0"
-
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -1186,12 +1045,6 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-duplexer2@~0.1.0:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
-  dependencies:
-    readable-stream "^2.0.2"
-
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -1205,13 +1058,6 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
-
-env-ci@^1.0.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/env-ci/-/env-ci-1.4.1.tgz#e4c68257270155db202f6ca9c61f6520ac6bfeaa"
-  dependencies:
-    execa "^0.9.0"
-    java-properties "^0.2.9"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
@@ -1380,10 +1226,6 @@ esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
-esprima@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.0.0.tgz#53cf247acda77313e551c3aa2e73342d3fb4f7d9"
-
 esquery@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
@@ -1426,18 +1268,6 @@ exec-sh@^0.2.0:
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
-execa@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -1743,17 +1573,6 @@ git-latest-semver-tag@^1.0.2:
     git-semver-tags "^1.1.2"
     meow "^3.3.0"
 
-git-log-parser@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/git-log-parser/-/git-log-parser-1.2.0.tgz#2e6a4c1b13fc00028207ba795a7ac31667b9fd4a"
-  dependencies:
-    argv-formatter "~1.0.0"
-    spawn-error-forwarder "~1.0.0"
-    split2 "~1.0.0"
-    stream-combiner2 "~1.1.1"
-    through2 "~2.0.0"
-    traverse "~0.6.6"
-
 git-raw-commits@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-0.1.2.tgz#2becbdcd3f96ef0b19f16863f7a2f6d9d8ab8369"
@@ -1787,19 +1606,6 @@ git-semver-tags@^1.0.0, git-semver-tags@^1.1.2, git-semver-tags@^1.3.2:
   dependencies:
     meow "^3.3.0"
     semver "^5.0.1"
-
-git-up@^2.0.0:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/git-up/-/git-up-2.0.10.tgz#20fe6bafbef4384cae253dc4f463c49a0c3bd2ec"
-  dependencies:
-    is-ssh "^1.3.0"
-    parse-url "^1.3.0"
-
-git-url-parse@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-8.1.0.tgz#d1ee09213efce5d8dc7a21bb03f17cfe0c111122"
-  dependencies:
-    git-up "^2.0.0"
 
 gitconfiglocal@^1.0.0:
   version "1.0.0"
@@ -1845,17 +1651,6 @@ globby@^5.0.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
-
-globby@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
-  dependencies:
-    array-union "^1.0.1"
-    dir-glob "^2.0.0"
-    glob "^7.1.2"
-    ignore "^3.3.5"
-    pify "^3.0.0"
-    slash "^1.0.0"
 
 got@^7.0.0:
   version "7.1.0"
@@ -2009,11 +1804,7 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-hook-std@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/hook-std/-/hook-std-0.4.0.tgz#fa8b2f84d358763137cb7d17e3308b28714bd174"
-
-hosted-git-info@^2.1.4, hosted-git-info@^2.4.2:
+hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
@@ -2055,15 +1846,9 @@ iconv-lite@0.4.19, iconv-lite@^0.4.17:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-ignore@^3.3.3, ignore@^3.3.5:
+ignore@^3.3.3:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
-
-import-from@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/import-from/-/import-from-2.1.0.tgz#335db7f2a7affd53aaa471d4b8021dee36b7f3b1"
-  dependencies:
-    resolve-from "^3.0.0"
 
 import-local@^1.0.0:
   version "1.0.0"
@@ -2082,10 +1867,6 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
-indent-string@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -2097,7 +1878,7 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, 
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.2, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
@@ -2141,10 +1922,6 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-is-array-buffer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-1.0.0.tgz#f32497a0509d109423f472003f98bab6a8ea34cb"
-
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -2172,10 +1949,6 @@ is-ci@^1.0.10:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
-
-is-directory@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -2294,12 +2067,6 @@ is-scoped@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-scoped/-/is-scoped-1.0.0.tgz#449ca98299e713038256289ecb2b540dc437cb30"
   dependencies:
     scoped-regex "^1.0.0"
-
-is-ssh@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.3.0.tgz#ebea1169a2614da392a63740366c3ce049d8dff6"
-  dependencies:
-    protocols "^1.1.0"
 
 is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
@@ -2434,10 +2201,6 @@ isurl@^1.0.0-alpha5:
   dependencies:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
-
-java-properties@^0.2.9:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/java-properties/-/java-properties-0.2.10.tgz#2551560c25fa1ad94d998218178f233ad9b18f60"
 
 jest-changed-files@^22.2.0:
   version "22.2.0"
@@ -2698,7 +2461,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.6.1, js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
+js-yaml@^3.6.1, js-yaml@^3.7.0, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -2922,10 +2685,6 @@ lodash._root@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
 
-lodash.assign@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
-
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -2998,10 +2757,6 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
-lodash.toarray@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
-
 lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.7.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
@@ -3061,20 +2816,6 @@ map-obj@^1.0.0, map-obj@^1.0.1:
 map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
-
-marked-terminal@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/marked-terminal/-/marked-terminal-2.0.0.tgz#5eaf568be66f686541afa52a558280310a31de2d"
-  dependencies:
-    cardinal "^1.0.0"
-    chalk "^1.1.3"
-    cli-table "^0.3.1"
-    lodash.assign "^4.2.0"
-    node-emoji "^1.4.1"
-
-marked@^0.3.9:
-  version "0.3.15"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.15.tgz#de96982e54c880962f5093a2fa93d0866bf73668"
 
 mem@^1.1.0:
   version "1.1.0"
@@ -3140,10 +2881,6 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
-
-mime@^2.0.3:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.2.0.tgz#161e541965551d3b549fa1114391e3a3d55b923b"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -3212,16 +2949,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-nerf-dart@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/nerf-dart/-/nerf-dart-1.0.0.tgz#e6dab7febf5ad816ea81cf5c629c5a0ebde72c1a"
-
-node-emoji@^1.4.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.8.1.tgz#6eec6bfb07421e2148c75c6bba72421f8530a826"
-  dependencies:
-    lodash.toarray "^4.4.0"
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -3258,7 +2985,7 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5, "normalize-package-data@~1.0.1 || ^2.0.0":
+normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   dependencies:
@@ -3277,29 +3004,13 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-url@2.0.1, normalize-url@^2.0.1:
+normalize-url@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-2.0.1.tgz#835a9da1551fa26f70e92329069a23aa6574d7e6"
   dependencies:
     prepend-http "^2.0.0"
     query-string "^5.0.1"
     sort-keys "^2.0.0"
-
-npm-conf@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/npm-conf/-/npm-conf-1.1.3.tgz#256cc47bd0e218c259c4e9550bf413bc2192aff9"
-  dependencies:
-    config-chain "^1.1.11"
-    pify "^3.0.0"
-
-"npm-package-arg@^3.0.0 || ^4.0.0 || ^5.0.0":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-5.1.2.tgz#fb18d17bb61e60900d6312619919bd753755ab37"
-  dependencies:
-    hosted-git-info "^2.4.2"
-    osenv "^0.1.4"
-    semver "^5.1.0"
-    validate-npm-package-name "^3.0.0"
 
 npm-publish-git-tag@^1.1.35:
   version "1.1.35"
@@ -3313,23 +3024,6 @@ npm-publish-git-tag@^1.1.35:
     set-npm-auth-token-for-ci "^1.0.14"
     shelljs "^0.8.0"
     write-pkg "^3.0.1"
-
-npm-registry-client@^8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/npm-registry-client/-/npm-registry-client-8.5.0.tgz#4878fb6fa1f18a5dc08ae83acf94d0d0112d7ed0"
-  dependencies:
-    concat-stream "^1.5.2"
-    graceful-fs "^4.1.6"
-    normalize-package-data "~1.0.1 || ^2.0.0"
-    npm-package-arg "^3.0.0 || ^4.0.0 || ^5.0.0"
-    once "^1.3.3"
-    request "^2.74.0"
-    retry "^0.10.0"
-    semver "2 >=2.2.1 || 3.x || 4 || 5"
-    slide "^1.1.3"
-    ssri "^4.1.2"
-  optionalDependencies:
-    npmlog "2 || ^3.1.0 || ^4.0.0"
 
 npm-run-all@^4.0.1:
   version "4.1.1"
@@ -3351,7 +3045,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-"npmlog@2 || ^3.1.0 || ^4.0.0", npmlog@^4.0.2:
+npmlog@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   dependencies:
@@ -3471,14 +3165,6 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
-p-reduce@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
-
-p-reflect@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-reflect/-/p-reflect-1.0.0.tgz#f4fa1ee1bb546d8eb3ec0321148dfe0a79137bb8"
-
 p-timeout@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-1.2.1.tgz#5eb3b353b7fce99f101a1038880bb054ebbea386"
@@ -3498,10 +3184,6 @@ p-try@^1.0.0:
 parse-github-repo-url@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz#9e7d8bb252a6cb6ba42595060b7bf6df3dbc1f50"
-
-parse-github-url@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/parse-github-url/-/parse-github-url-1.0.2.tgz#242d3b65cbcdda14bb50439e3242acf6971db395"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -3524,13 +3206,6 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
-
-parse-url@^1.3.0:
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-1.3.11.tgz#57c15428ab8a892b1f43869645c711d0e144b554"
-  dependencies:
-    is-ssh "^1.3.0"
-    protocols "^1.4.0"
 
 parse5@4.0.0:
   version "4.0.0"
@@ -3673,14 +3348,6 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
-proto-list@~1.2.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
-
-protocols@^1.1.0, protocols@^1.4.0:
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.6.tgz#f8bb263ea1b5fd7a7604d26b8be39bd77678bf8a"
-
 ps-tree@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
@@ -3726,7 +3393,7 @@ randomatic@^1.1.3:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
+rc@^1.0.1, rc@^1.1.7:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.5.tgz#275cd687f6e3b36cc756baa26dfee80a790301fd"
   dependencies:
@@ -3748,13 +3415,6 @@ read-pkg-up@^2.0.0:
   dependencies:
     find-up "^2.0.0"
     read-pkg "^2.0.0"
-
-read-pkg-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
-  dependencies:
-    find-up "^2.0.0"
-    read-pkg "^3.0.0"
 
 read-pkg@^1.0.0, read-pkg@^1.1.0:
   version "1.1.0"
@@ -3780,7 +3440,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
   dependencies:
@@ -3832,12 +3492,6 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-redeyed@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-1.0.1.tgz#e96c193b40c0816b00aec842698e61185e55498a"
-  dependencies:
-    esprima "~3.0.0"
-
 regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
@@ -3847,13 +3501,6 @@ regex-cache@^0.4.2:
   resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
   dependencies:
     is-equal-shallow "^0.1.3"
-
-registry-auth-token@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
-  dependencies:
-    rc "^1.1.6"
-    safe-buffer "^5.0.1"
 
 registry-url@^3.1.0:
   version "3.1.0"
@@ -3920,7 +3567,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.74.0, request@^2.79.0, request@^2.83.0:
+request@^2.79.0, request@^2.83.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:
@@ -3951,10 +3598,6 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
-require-from-string@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
-
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -3980,10 +3623,6 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
-resolve-from@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
-
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
@@ -4006,10 +3645,6 @@ restore-cursor@^2.0.0:
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
-
-retry@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -4039,7 +3674,7 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
@@ -4109,39 +3744,11 @@ semantic-release-github@^3.1.2:
     shifted-semver-increment "^1.0.3"
     stream-to-array "^2.3.0"
 
-semantic-release@^12.4.1:
-  version "12.4.1"
-  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-12.4.1.tgz#4faeee44fe7fbebbc7af8cc9e3522eb7877a0260"
-  dependencies:
-    "@semantic-release/commit-analyzer" "^5.0.0"
-    "@semantic-release/error" "^2.1.0"
-    "@semantic-release/github" "^3.0.1"
-    "@semantic-release/npm" "^2.0.0"
-    "@semantic-release/release-notes-generator" "^6.0.0"
-    aggregate-error "^1.0.0"
-    chalk "^2.3.0"
-    commander "^2.11.0"
-    cosmiconfig "^4.0.0"
-    debug "^3.1.0"
-    env-ci "^1.0.0"
-    execa "^0.9.0"
-    get-stream "^3.0.0"
-    git-log-parser "^1.2.0"
-    hook-std "^0.4.0"
-    lodash "^4.17.4"
-    marked "^0.3.9"
-    marked-terminal "^2.0.0"
-    p-reduce "^1.0.0"
-    p-reflect "^1.0.0"
-    read-pkg-up "^3.0.0"
-    resolve-from "^4.0.0"
-    semver "^5.4.1"
-
 semver-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-1.0.0.tgz#92a4969065f9c70c694753d55248fc68f8f652c9"
 
-"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.4.1:
+"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -4217,10 +3824,6 @@ slice-ansi@1.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
 
-slide@^1.1.3:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
-
 sntp@1.x.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
@@ -4265,10 +3868,6 @@ source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
-spawn-error-forwarder@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz#1afd94738e999b0346d7b9fc373be55e07577029"
-
 spdx-correct@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
@@ -4294,12 +3893,6 @@ split2@^2.0.0:
   resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
   dependencies:
     through2 "^2.0.2"
-
-split2@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/split2/-/split2-1.0.0.tgz#52e2e221d88c75f9a73f90556e263ff96772b314"
-  dependencies:
-    through2 "~2.0.0"
 
 split@0.3:
   version "0.3.3"
@@ -4331,12 +3924,6 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-ssri@^4.1.2:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-4.1.6.tgz#0cb49b6ac84457e7bdd466cb730c3cb623e9a25b"
-  dependencies:
-    safe-buffer "^5.1.0"
-
 stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
@@ -4350,13 +3937,6 @@ stream-array@^1.1.2:
   resolved "https://registry.yarnpkg.com/stream-array/-/stream-array-1.1.2.tgz#9e5f7345f2137c30ee3b498b9114e80b52bb7eb5"
   dependencies:
     readable-stream "~2.1.0"
-
-stream-combiner2@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stream-combiner2/-/stream-combiner2-1.1.1.tgz#fb4d8a1420ea362764e21ad4780397bebcb41cbe"
-  dependencies:
-    duplexer2 "~0.1.0"
-    readable-stream "^2.0.2"
 
 stream-combiner@~0.0.4:
   version "0.0.4"
@@ -4585,10 +4165,6 @@ tr46@^1.0.0:
   dependencies:
     punycode "^2.1.0"
 
-traverse@~0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
-
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -4654,10 +4230,6 @@ universalify@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
-url-join@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/url-join/-/url-join-3.0.0.tgz#26e8113ace195ea30d0fc38186e45400f9cea672"
-
 url-parse-lax@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
@@ -4669,10 +4241,6 @@ url-parse-lax@^3.0.0:
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
   dependencies:
     prepend-http "^2.0.0"
-
-url-template@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
 
 url-to-options@^1.0.1:
   version "1.0.1"
@@ -4705,12 +4273,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
-
-validate-npm-package-name@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
-  dependencies:
-    builtins "^1.0.3"
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
fixes #86 
closes #93 

In addition to converting jsonTokenTemplateValues to async this PR ensures that schemePunk plugins that rely on pathing will be provided the correct paths from the module that is implementing schemePunk. This should clean up the issues with callsite and v8 stack as well as just assume a more declarative stance, which is in the spirit of SchemePunk in the first place.

Since this was going to be a breaking change I decided to bundle in a few other needed changes.

- Ensured that schemePunk could now safely take advantage of molotov's dynamic plugins capability.
- Wrote the souce json template plugin so that it was also async.
- Eliminated use of requireDirectory for plugins in lieu of index.js files in plugins and supers.

thank you @elliotttf for getting this started. - @thebruce