### PR TITLE
fix: correctly make all transforms async

### DIFF
--- a/__tests__/plugins/transform/typeAdapter.js
+++ b/__tests__/plugins/transform/typeAdapter.js
@@ -8,7 +8,7 @@ class BaseXform {
   }
 
   transform(value) { // eslint-disable-line class-methods-use-this
-    return value;
+    return Promise.resolve(value);
   }
 }
 
@@ -16,17 +16,21 @@ const prePend = require('../../../lib/plugins/transform/prependValues');
 
 const Implemented = class implementer extends TypeAdapter(prePend(BaseXform)) {
   transform(value) {
-    this.value = super.transform(value);
-    // Return for the purposes of this unit test.
-    return this.value;
+    return super.transform(value)
+      .then((xformedValue) => {
+        this.value = xformedValue;
+        return this.value;
+      });
   }
 };
 
 const Implemented2 = class implementer extends TypeAdapter(BaseXform) {
   transform(value) {
-    this.value = super.transform(value);
-    // Return for the purposes of this unit test.
-    return this.value;
+    return super.transform(value)
+      .then((xformedValue) => {
+        this.value = xformedValue;
+        return this.value;
+      });
   }
 };
 
@@ -63,32 +67,41 @@ describe('Append Values test', () => {
       sourcePrepend: 'thething',
       adapterPrevent: ['number']
     };
-    expect(typeAdapter.transform(testString)).toBe('thethingtestString');
+    return typeAdapter.transform(testString)
+      .then((val) => {
+        expect(val).toBe('thethingtestString');
+      });
   });
   test('test array.', () => {
     typeAdapter.options = {
       sourcePrepend: 'thething',
       adapterPrevent: []
     };
-    expect(typeAdapter.transform(testArray)).toEqual([
-      'thethingtest1',
-      'thethingtest2',
-      'thethingtest3'
-    ]);
+    return typeAdapter.transform(testArray)
+      .then((val) => {
+        expect(val).toEqual([
+          'thethingtest1',
+          'thethingtest2',
+          'thethingtest3'
+        ]);
+      });
   });
   test('test object.', () => {
     typeAdapter.options = {
       sourcePrepend: 'thething',
       adapterPrevent: ['number']
     };
-    expect(typeAdapter.transform(testObject)).toEqual({
-      thethingtest1: [
-        'test'
-      ],
-      thethingtest2: [
-        'boo'
-      ]
-    });
+    return typeAdapter.transform(testObject)
+      .then((val) => {
+        expect(val).toEqual({
+          thethingtest1: [
+            'test'
+          ],
+          thethingtest2: [
+            'boo'
+          ]
+        });
+      });
   });
   test('test object values.', () => {
     typeAdapter.options = {
@@ -96,10 +109,13 @@ describe('Append Values test', () => {
       adapterPrevent: ['number']
     };
     typeAdapter.options.typeAdapterObjectValues = true;
-    expect(typeAdapter.transform(testObject)).toEqual({
-      test1: 'thethingtest',
-      test2: 'thethingboo'
-    });
+    return typeAdapter.transform(testObject)
+      .then((val) => {
+        expect(val).toEqual({
+          test1: 'thethingtest',
+          test2: 'thethingboo'
+        });
+      });
   });
   test('test object array.', () => {
     typeAdapter.options = {
@@ -108,10 +124,13 @@ describe('Append Values test', () => {
     };
     typeAdapter.options.typeAdapterObjectValues = false;
     typeAdapter.options.typeAdapterObjectValuesArray = true;
-    expect(typeAdapter.transform(testObject)).toEqual([
-      'thethingtest',
-      'thethingboo'
-    ]);
+    return typeAdapter.transform(testObject)
+      .then((val) => {
+        expect(val).toEqual([
+          'thethingtest',
+          'thethingboo'
+        ]);
+      });
   });
   test('Test boolean throws', () => {
     expect(() => typeAdapter.transform(true)).toThrow();
@@ -120,14 +139,20 @@ describe('Append Values test', () => {
     typeAdapter.options = {
       adapterPrevent: 'number'
     };
-    expect(typeAdapter.transform(testNumber)).toEqual(1);
+    return typeAdapter.transform(testNumber)
+      .then((val) => {
+        expect(val).toEqual(1);
+      });
   });
   test('test Number.', () => {
     typeAdapter.options = {
       sourcePrepend: 'thething',
       adapterPrevent: []
     };
-    expect(typeAdapter.transform(testNumber)).toEqual('thething1');
+    return typeAdapter.transform(testNumber)
+      .then((val) => {
+        expect(val).toEqual('thething1');
+      });
   });
   test('test Null.', () => {
     typeAdapter.options = {
@@ -146,9 +171,11 @@ describe('Append Values test', () => {
       item1: 'thing',
       item2: {}
     };
-    typeAdapter2.transform(testObjecta);
-    expect(typeAdapter2.value).toEqual({
-      item1: 'thing'
-    });
+    return typeAdapter2.transform(testObjecta)
+      .then(() => {
+        expect(typeAdapter2.value).toEqual({
+          item1: 'thing'
+        });
+      });
   });
 });

--- a/__tests__/supers/transform.js
+++ b/__tests__/supers/transform.js
@@ -71,8 +71,10 @@ describe('Scheme Punk Transform Super', () => {
 
   test('transform', () => {
     expect.assertions(1);
-    return expect(schemePunkTransform.transform('transformTest'))
-      .toEqual('transformTest');
+    return schemePunkTransform.transform('transformTest')
+      .then((val) => {
+        expect(val).toEqual('transformTest');
+      });
   });
 
   test('call ', () => {

--- a/lib/plugins/transform/typeAdapter.js
+++ b/lib/plugins/transform/typeAdapter.js
@@ -32,7 +32,7 @@ module.exports = superclass => class extends superclass {
       // Attempt to call method based on object.
       tempValue = this[`${varType}Adapter`](value);
     }
-    return tempValue;
+    return Promise.resolve(tempValue);
   }
 
   /**   ___
@@ -80,40 +80,49 @@ module.exports = superclass => class extends superclass {
 
   // array
   arrayAdapter(value) {
-    const newValue = value.map(super.transform, this);
-    return newValue;
+    return Promise.all(value.map(val => super.transform(val)))
+      .then(newValue => newValue);
   }
 
   // object
   objectKeysAdapter(value) {
     const newValue = {};
-    Object.keys(value).forEach((key) => {
-      const newKey = super.transform(`${key}`);
-      newValue[newKey] = value[key];
-    });
-    return newValue;
+    return Promise.all(Object.keys(value).map(key => super.transform(`${key}`)
+      .then(newKey => ({
+        key,
+        newKey,
+      }))))
+      .then((xforms) => {
+        xforms.forEach(({key, newKey}) => {
+          newValue[newKey] = value[key];
+        });
+      })
+      .then(() => newValue);
   }
 
   // object
   objectValuesAdapter(value) {
     const newValue = {};
-    Object.keys(value).forEach((key) => {
-      const tmpValue = super.transform(value[key]);
-      newValue[key] = tmpValue;
-      if (_.isEmpty(tmpValue) && !_.get(this.options, 'typeAdapter.includeEmpty', true)) {
-        delete newValue[key];
-      }
-    });
-    return newValue;
+
+    return Promise.all(Object.keys(value).map(key => super.transform(value[key])
+      .then(tmpValue => ({
+        key,
+        tmpValue,
+      }))))
+      .then((xforms) => {
+        xforms.forEach(({key, tmpValue}) => {
+          newValue[key] = tmpValue;
+          if (_.isEmpty(tmpValue) && !_.get(this.options, 'typeAdapter.includeEmpty', true)) {
+            delete newValue[key];
+          }
+        });
+      })
+      .then(() => newValue);
   }
 
   // object
   objectValuesArrayAdapter(value) {
-    const newValue = [];
-    Object.keys(value).forEach((key) => {
-      newValue.push(super.transform(value[key]));
-    });
-    return newValue;
+    return Promise.all(Object.keys(value).map(key => super.transform(value[key])));
   }
 
   stringAdapter(value) {

--- a/lib/schemePunk.js
+++ b/lib/schemePunk.js
@@ -81,16 +81,12 @@ module.exports = class schemePunk {
         ), source]);
       })
       .then(([transformer, source]) => Promise.all([transformer, transformer.transform(source)]))
-      .then(([transformer]) => {
-        // Get the transformed value.
-        const transformedValue = transformer.getTransformedValue();
-        // Get Scheme.
-        return Promise.all([
+      .then(([transformer]) => transformer.getTransformedValue()
+        .then(transformedValue => Promise.all([
           schemePunkDestinationBase(this.options.destination.plugin, this.molotovConfig),
           transformedValue,
           transformer
-        ]);
-      })
+        ])))
       .then(([SchemeDestination, transformValue, transformerInstance]) => {
         const schemeDestination = new SchemeDestination();
         return schemeDestination.init(

--- a/lib/supers/transform.js
+++ b/lib/supers/transform.js
@@ -26,7 +26,7 @@ module.exports = class schemePunkTransform {
    *  A value to perform a transformation upon.
    */
   transform(value) { // eslint-ignore
-    return value;
+    return Promise.resolve(value);
   }
 
   /**

--- a/lib/transform/schemePunkTransform.js
+++ b/lib/transform/schemePunkTransform.js
@@ -28,7 +28,10 @@ module.exports = function transformFactory(pluginName, molotovConfig) {
      *  A value to perform a transformation upon.
      */
     transform(value) {
-      this.value = super.transform(value);
+      return super.transform(value)
+        .then((xformedValue) => {
+          this.value = xformedValue;
+        });
     }
   });
 };


### PR DESCRIPTION
Additionally, the calling of `getTransformedValue()` was previously
made asynchronous but not being called in an async way.