### PR TITLE
feat(typeAdapter): provide objectValuesMergeAdapter

### DIFF
--- a/__tests__/plugins/transform/typeAdapter.js
+++ b/__tests__/plugins/transform/typeAdapter.js
@@ -57,6 +57,22 @@ const testObject = {
   ]
 };
 
+const testObjectMerge = {
+  test1: {
+    foo: 'bar',
+    ary: [
+      1
+    ]
+  },
+  test2: {
+    bar: 'baz',
+    ary: [
+      1
+    ]
+  },
+  test3: {}
+};
+
 const testNull = null;
 
 const testNumber = 1;
@@ -114,6 +130,43 @@ describe('Append Values test', () => {
         expect(val).toEqual({
           test1: 'thethingtest',
           test2: 'thethingboo'
+        });
+      });
+  });
+  test('test object merge.', () => {
+    typeAdapter2.options = {
+      typeAdapterObjectValuesMerge: true,
+      typeAdapter: {
+        includeEmpty: false
+      }
+    };
+    typeAdapter2.options.typeAdapterObjectValuesMerge = true;
+    return typeAdapter2.transform(testObjectMerge)
+      .then((val) => {
+        expect(val).toEqual({
+          ary: [1],
+          foo: 'bar',
+          bar: 'baz',
+        });
+
+        typeAdapter2.options.typeAdapter.concatArrays = true;
+        return typeAdapter2.transform(testObjectMerge);
+      })
+      .then((val) => {
+        expect(val).toEqual({
+          ary: [1, 1],
+          foo: 'bar',
+          bar: 'baz',
+        });
+
+        typeAdapter2.options.typeAdapter.uniqArrays = true;
+        return typeAdapter2.transform(testObjectMerge);
+      })
+      .then((val) => {
+        expect(val).toEqual({
+          ary: [1],
+          foo: 'bar',
+          bar: 'baz',
         });
       });
   });

--- a/lib/plugins/transform/typeAdapter.js
+++ b/lib/plugins/transform/typeAdapter.js
@@ -2,6 +2,22 @@
 
 const _ = require('lodash');
 
+function _showMeWhatYouGotObject(value, options) {
+  if (_.isArray(value)) {
+    return 'array';
+  }
+  if (options.typeAdapterObjectValues) {
+    return 'objectValues';
+  }
+  if (options.typeAdapterObjectValuesArray) {
+    return 'objectValuesArray';
+  }
+  if (options.typeAdapterObjectValuesMerge) {
+    return 'objectValuesMerge';
+  }
+  return 'objectKeys';
+}
+
 /**
  * This is a transformation mixin for SchemePunk.
  * SchemePunk mixins follow the formula for mixins described at:
@@ -58,16 +74,7 @@ module.exports = superclass => class extends superclass {
       return 'null';
     }
     if (_.isObjectLike(this.value)) {
-      if (_.isArray(this.value)) {
-        return 'array';
-      }
-      if (this.options.typeAdapterObjectValues) {
-        return 'objectValues';
-      }
-      if (this.options.typeAdapterObjectValuesArray) {
-        return 'objectValuesArray';
-      }
-      return 'objectKeys';
+      return _showMeWhatYouGotObject(this.value, this.options);
     }
     if (_.isString(this.value)) {
       return 'string';
@@ -114,6 +121,36 @@ module.exports = superclass => class extends superclass {
           newValue[key] = tmpValue;
           if (_.isEmpty(tmpValue) && !_.get(this.options, 'typeAdapter.includeEmpty', true)) {
             delete newValue[key];
+          }
+        });
+      })
+      .then(() => newValue);
+  }
+
+  // object
+  objectValuesMergeAdapter(value) {
+    const newValue = {};
+    return Promise.all(Object.keys(value).map(key => super.transform(value[key])
+      .then(tmpValue => ({
+        tmpValue,
+      }))))
+      .then((xforms) => {
+        xforms.forEach(({tmpValue}) => {
+          if (!_.isEmpty(tmpValue) || _.get(this.options, 'typeAdapter.includeEmpty', true)) {
+            if (_.get(this.options, 'typeAdapter.concatArrays', false)) {
+              _.mergeWith(newValue, tmpValue, (objValue, srcValue) => {
+                if (Array.isArray(objValue)) {
+                  if (_.get(this.options, 'typeAdapter.uniqArrays', false)) {
+                    return _.uniq([...objValue, ...srcValue]);
+                  }
+                  return [...objValue, ...srcValue];
+                }
+                return undefined;
+              });
+            }
+            else {
+              _.merge(newValue, tmpValue);
+            }
           }
         });
       })

--- a/lib/plugins/transform/typeAdapter.js
+++ b/lib/plugins/transform/typeAdapter.js
@@ -130,12 +130,9 @@ module.exports = superclass => class extends superclass {
   // object
   objectValuesMergeAdapter(value) {
     const newValue = {};
-    return Promise.all(Object.keys(value).map(key => super.transform(value[key])
-      .then(tmpValue => ({
-        tmpValue,
-      }))))
+    return Promise.all(Object.keys(value).map(key => super.transform(value[key])))
       .then((xforms) => {
-        xforms.forEach(({tmpValue}) => {
+        xforms.forEach((tmpValue) => {
           if (!_.isEmpty(tmpValue) || _.get(this.options, 'typeAdapter.includeEmpty', true)) {
             if (_.get(this.options, 'typeAdapter.concatArrays', false)) {
               _.mergeWith(newValue, tmpValue, (objValue, srcValue) => {
@@ -153,8 +150,8 @@ module.exports = superclass => class extends superclass {
             }
           }
         });
-      })
-      .then(() => newValue);
+        return newValue;
+      });
   }
 
   // object

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prepush": "npm test",
     "coveralls": "cat ./__coverage__/lcov.info | coveralls",
     "test": "jest --coverage",
+    "debug-test": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "npmpublish": "npm-publish-git-tag --access public"
   },
   "repository": {


### PR DESCRIPTION
This adapter will by default use `_.merge()` but can be configured
to use _.mergeWith() to concatinate arrays and additionally to do
so uniquely. The relevant options are:

* `typeAdapter.concatArrays: true`
* `typeAdapter.uniqArrays: true`