### PR TITLE
fix: prevent modifying non-objects

### DIFF
--- a/__tests__/plugins/transform/filterObjects.js
+++ b/__tests__/plugins/transform/filterObjects.js
@@ -68,10 +68,4 @@ describe('Delimit Values tests', () => {
       },
     });
   });
-  test('Bypasses non-objects', () => {
-    expect.assertions(1);
-    value.test = true;
-    filterObjectValues.options.filterBias = 'in';
-    expect(filterObjectValues.transform(true)).toEqual(true);
-  });
 });

--- a/__tests__/plugins/transform/filterObjects.js
+++ b/__tests__/plugins/transform/filterObjects.js
@@ -45,6 +45,7 @@ describe('Delimit Values tests', () => {
   });
 
   test('Filter out.', () => {
+    expect.assertions(1);
     filterObjectValues.options.filterBias = 'out';
     expect(filterObjectValues.transform(value)).toEqual({
       attribute3: {},
@@ -54,6 +55,7 @@ describe('Delimit Values tests', () => {
     });
   });
   test('Filter in.', () => {
+    expect.assertions(1);
     filterObjectValues.options.filterBias = 'in';
     expect(filterObjectValues.transform(value)).toEqual({
       attribute1: {
@@ -65,5 +67,11 @@ describe('Delimit Values tests', () => {
         },
       },
     });
+  });
+  test('Bypasses non-objects', () => {
+    expect.assertions(1);
+    value.test = true;
+    filterObjectValues.options.filterBias = 'in';
+    expect(filterObjectValues.transform(true)).toEqual(true);
   });
 });

--- a/lib/molotov.json
+++ b/lib/molotov.json
@@ -48,7 +48,6 @@
           "filterAttributes"
         ],
         "filterObject": [
-          "typeAdapter",
           "filterObjects"
         ],
         "filterObjectMulti": [

--- a/lib/plugins/transform/filterObjects.js
+++ b/lib/plugins/transform/filterObjects.js
@@ -21,6 +21,10 @@ module.exports = superclass => class extends superclass {
     // This is the bias.
     const filterBias = _.get(this, 'options.filterBias', 'out');
 
+    if (!_.isPlainObject(value)) {
+      return super.transform(value);
+    }
+
     const tempValue = _.pickBy(value, (predicate) => {
       const filterPath = Object.keys(predicate)
         .find(predicateKey => filterItems.find(fullPath => fullPath.startsWith(predicateKey)));

--- a/lib/plugins/transform/filterObjects.js
+++ b/lib/plugins/transform/filterObjects.js
@@ -21,10 +21,6 @@ module.exports = superclass => class extends superclass {
     // This is the bias.
     const filterBias = _.get(this, 'options.filterBias', 'out');
 
-    if (!_.isPlainObject(value)) {
-      return super.transform(value);
-    }
-
     const tempValue = _.pickBy(value, (predicate) => {
       const filterPath = Object.keys(predicate)
         .find(predicateKey => filterItems.find(fullPath => fullPath.startsWith(predicateKey)));


### PR DESCRIPTION
This removes the type adapter from `filterObject` so that the target object is directly operated on instead of an adapted version of that object.